### PR TITLE
feat: add `schedule` mongoose model with typescript

### DIFF
--- a/apps/server/src/models/schedule.ts
+++ b/apps/server/src/models/schedule.ts
@@ -15,7 +15,7 @@ export class Schedule extends TimeStamps {
     @prop()
     public name: string
 
-    @prop()
+    @prop({ validate: { validator: v => v.type === 'Point' && v.coordinates?.length === 2 } })
     public location: {
         type: string
         coordinates: number[]

--- a/apps/server/src/models/schedule.ts
+++ b/apps/server/src/models/schedule.ts
@@ -1,0 +1,39 @@
+import { getModelForClass, prop } from '@typegoose/typegoose'
+import mongoose from 'mongoose'
+import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
+
+export class Schedule extends TimeStamps {
+    public _id: mongoose.Types.ObjectId
+
+    @prop({ required: true })
+    public authorId: string
+
+    @prop({ required: true })
+    public eventId: string
+
+    @prop()
+    public name: string
+
+    @prop()
+    public location: number[]
+
+    @prop()
+    public address: string
+
+    @prop({ required: true })
+    public startDate: Date
+
+    @prop({ required: true })
+    public endDate: Date
+
+    @prop()
+    public description: string
+
+    @prop()
+    public images: string[]
+
+    @prop()
+    public createdAt: Date
+}
+
+export const ScheduleModel = getModelForClass(Schedule)

--- a/apps/server/src/models/schedule.ts
+++ b/apps/server/src/models/schedule.ts
@@ -1,8 +1,7 @@
-import { getModelForClass, prop, index } from '@typegoose/typegoose'
+import { getModelForClass, prop } from '@typegoose/typegoose'
 import mongoose from 'mongoose'
 import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
 
-@index({ location: '2dsphere' })
 export class Schedule extends TimeStamps {
     public _id: mongoose.Types.ObjectId
 

--- a/apps/server/src/models/schedule.ts
+++ b/apps/server/src/models/schedule.ts
@@ -1,7 +1,8 @@
-import { getModelForClass, prop } from '@typegoose/typegoose'
+import { getModelForClass, prop, index } from '@typegoose/typegoose'
 import mongoose from 'mongoose'
 import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
 
+@index({ location: '2dsphere' })
 export class Schedule extends TimeStamps {
     public _id: mongoose.Types.ObjectId
 
@@ -15,7 +16,10 @@ export class Schedule extends TimeStamps {
     public name: string
 
     @prop()
-    public location: number[]
+    public location: {
+        type: string
+        coordinates: number[]
+    }
 
     @prop()
     public address: string


### PR DESCRIPTION
* schedule 모델보다 event, user 모델이 먼저 정의되어야합니다.
* 이에 따라서, 현재 `authorId`, `eventId`는 레퍼런스로 연결되어있지 않습니다. 
    * 추후에 event, user모델이 추가된다면 레퍼런스로 연결하는 PR을 올릴 예정입니다.