### PR TITLE
feat: add `[POST] /schedule` API

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -36,8 +36,6 @@
         "@types/express": "^5.0.0",
         "@types/hpp": "^0.2.6",
         "@types/jest": "^29.5.14",
-        "@types/multer": "^1.4.12",
-        "multer": "1.4.5-lts.1",
         "nodemon": "^3.1.7",
         "swc-node": "^1.0.0"
     }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -36,6 +36,8 @@
         "@types/express": "^5.0.0",
         "@types/hpp": "^0.2.6",
         "@types/jest": "^29.5.14",
+        "@types/multer": "^1.4.12",
+        "multer": "1.4.5-lts.1",
         "nodemon": "^3.1.7",
         "swc-node": "^1.0.0"
     }

--- a/apps/server/src/controllers/v1/index.ts
+++ b/apps/server/src/controllers/v1/index.ts
@@ -1,5 +1,7 @@
 import enquiries from './enquiries'
+import schedule from './schedule'
 
 export default {
     enquiries,
+    schedule,
 }

--- a/apps/server/src/controllers/v1/schedule.ts
+++ b/apps/server/src/controllers/v1/schedule.ts
@@ -6,9 +6,9 @@ const router = asyncify(express.Router())
 
 // TODO: add validator(eventId, authorId)
 router.post('/', async (req: Request, res: Response) => {
-    const { title, eventId, startDate, endDate, address, location, description, images } = req.body
+    const { name, eventId, startDate, endDate, address, location, description, images } = req.body
     const schedule = await ScheduleModel.create({
-        name: title,
+        name: name,
         eventId: eventId,
         startDate: startDate,
         endDate: endDate,

--- a/apps/server/src/controllers/v1/schedule.ts
+++ b/apps/server/src/controllers/v1/schedule.ts
@@ -1,36 +1,24 @@
 import asyncify from 'express-asyncify'
-import multer from 'multer'
 import express, { Request, Response } from 'express'
 import { ScheduleModel } from '@/models/schedule'
 
-type Callback = { error: Error | null; fileName: string }
 const router = asyncify(express.Router())
-const storage = multer.diskStorage({
-    // 아래의 경로는 테스트를 위한 임시 경로입니다.
-    destination: './upload/schedule',
-    // 별도의 파일 서비스로 분리하기 전에는, 임시적으로 원본 파일 이름을 그대로 사용합니다.
-    filename: (req: Request, file: Express.Multer.File, callback: Callback) => {
-        callback(null, file.originalname)
-    },
-})
-// TODO: 추후 파일명 검증과 같은 설정 추가
-const fileUpload = multer({ storage: storage })
 
-// TODO: 모델을 저장 성공하는 경우에만 스토리지에 파일 저장
-router.post('/', fileUpload.array('images'), async (req: Request, res: Response) => {
-    const jsonData = JSON.parse(req.body.jsonData)
-    const savedImageNames = req.files.map(image => image.originalname)
+// TODO: add validator(eventId, authorId)
+router.post('/', async (req: Request, res: Response) => {
+    const { title, eventId, startDate, endDate, address, location, description, savedImageUrls } = req.body
     const schedule = await ScheduleModel.create({
-        name: jsonData.title,
-        startDate: jsonData.startDate,
-        endDate: jsonData.endDate,
-        address: jsonData.address,
+        name: title,
+        eventId: eventId,
+        startDate: startDate,
+        endDate: endDate,
+        address: address,
         location: {
             type: 'Point',
-            coordinates: [jsonData.location.longitude, jsonData.location.latitude],
+            coordinates: [location.longitude, location.latitude],
         },
-        description: jsonData.description,
-        images: savedImageNames,
+        description: description,
+        images: savedImageUrls,
     })
     res.status(201).json({
         scheduleId: schedule._id,

--- a/apps/server/src/controllers/v1/schedule.ts
+++ b/apps/server/src/controllers/v1/schedule.ts
@@ -1,0 +1,40 @@
+import asyncify from 'express-asyncify'
+import multer from 'multer'
+import express, { Request, Response } from 'express'
+import { ScheduleModel } from '@/models/schedule'
+
+type Callback = { error: Error | null; fileName: string }
+const router = asyncify(express.Router())
+const storage = multer.diskStorage({
+    // 아래의 경로는 테스트를 위한 임시 경로입니다.
+    destination: './upload/schedule',
+    // 별도의 파일 서비스로 분리하기 전에는, 임시적으로 원본 파일 이름을 그대로 사용합니다.
+    filename: (req: Request, file: Express.Multer.File, callback: Callback) => {
+        callback(null, file.originalname)
+    },
+})
+// TODO: 추후 파일명 검증과 같은 설정 추가
+const fileUpload = multer({ storage: storage })
+
+// TODO: 모델을 저장 성공하는 경우에만 스토리지에 파일 저장
+router.post('/', fileUpload.array('images'), async (req: Request, res: Response) => {
+    const jsonData = JSON.parse(req.body.jsonData)
+    const savedImageNames = req.files.map(image => image.originalname)
+    const schedule = await ScheduleModel.create({
+        name: jsonData.title,
+        startDate: jsonData.startDate,
+        endDate: jsonData.endDate,
+        address: jsonData.address,
+        location: {
+            type: 'Point',
+            coordinates: [jsonData.location.longitude, jsonData.location.latitude],
+        },
+        description: jsonData.description,
+        images: savedImageNames,
+    })
+    res.status(201).json({
+        scheduleId: schedule._id,
+    })
+})
+
+export default router

--- a/apps/server/src/controllers/v1/schedule.ts
+++ b/apps/server/src/controllers/v1/schedule.ts
@@ -6,19 +6,16 @@ const router = asyncify(express.Router())
 
 // TODO: add validator(eventId, authorId)
 router.post('/', async (req: Request, res: Response) => {
-    const { title, eventId, startDate, endDate, address, location, description, savedImageUrls } = req.body
+    const { title, eventId, startDate, endDate, address, location, description, images } = req.body
     const schedule = await ScheduleModel.create({
         name: title,
         eventId: eventId,
         startDate: startDate,
         endDate: endDate,
         address: address,
-        location: {
-            type: 'Point',
-            coordinates: [location.longitude, location.latitude],
-        },
+        location: location,
         description: description,
-        images: savedImageUrls,
+        images: images,
     })
     res.status(201).json({
         scheduleId: schedule._id,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -33,6 +33,7 @@ export default class Server {
 
     setController() {
         this.app.use('/v1/enquiry', controllers.v1.enquiries)
+        this.app.use('/v1/schedule', controllers.v1.schedule)
     }
 
     setPostMiddleware() {}


### PR DESCRIPTION
<details><summary>이전 내용</summary>
<p>
* 현재는 빠르게 프로토타입만 돌아갈 수 있도록 아래와 같이 구현하였습니다.<br/>
   1. 디스크 기반의 저장<br/>
     * 추후에 s3 인스턴스가 할당된다면 해당 인스턴스에 저장하도록 수정할게요!<br/>
   3. 원본 파일명 저장<br/>
<br/>
* 추후에 `파일 이름 충돌`을 방지하기 위해서 파일명을 해싱한다음 저장하고 `파일 테이블 (원본 파일명, 저장된 파일명)`을 분리하는 것이 어떨까 생각이 드는데요<br/>
* 또, 현재의 요구사항으로는 딱히 보이진 않는데요. 추후에 `일정`에 대한 정보를 `나만 보기`로 설정하는 기능이 추가된다면, 이미지 파일에 대한 접근 권한 또한 생각해야하기 때문에 `파일 서비스`로 아예 분리하는 것도 좋아보입니다.<br/>
</p>
</details> 

---
<리뷰 반영>
* 이미지 업로드 API를 분리하여 구현하는 것으로 결정된 만큼, 기존의 `multipart/form-data`형식의 MIME 타입을 고집할 이유가 없어져서 `application/json` 형식으로 받도록 수정하였습니다.
* 해당 API를 trigger하는 event 의 정보를 포함시키기 위해서 `eventId` 가 request body에 포함되도록 하였습니다.
  * 추후 validation middleware를 추가할 예정입니다.
  