### PR TITLE
refactor: change type of eventId in schedule model

### DIFF
--- a/apps/server/src/models/schedule.ts
+++ b/apps/server/src/models/schedule.ts
@@ -12,7 +12,7 @@ export class Schedule extends TimeStamps {
     public authorId: mongoose.Types.ObjectId
 
     @prop({ required: true, ref: Events })
-    public eventId: string
+    public eventId: mongoose.Types.ObjectId
 
     @prop()
     public name: string


### PR DESCRIPTION
schedule model의 타입을 string에서 objectId로 변경하였습니다