### PR TITLE
fix: paginated result의 inconsistency 수정

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -51,7 +51,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 })
 
 router.get('/category/:category', async (req: Request, res: Response) => {
-    const options = { sort: { createdAt: -1 }, page: Number(req.query.page) || 1, limit: Number(req.query.limit) || 10 }
+    const options = { sort: { startDate: 1, endDate: 1, createdAt: -1 }, page: Number(req.query.page) || 1, limit: Number(req.query.limit) || 10 }
     const category = req.params.category
     const result = await EventsModel.findByCategory(category, options)
 


### PR DESCRIPTION
* ❌ event 목록 조회 관련된 API에서 limit 크기에 따라서 "원하는 순서"대로 데이터가 전달되지 않음을 확인하였습니다.
  * limit 크기가 동일한 경우 동일한 결과를 볼 수 있었던 것은 mongodb의 [쿼리 캐시](https://www.mongodb.com/ko-kr/docs/manual/core/query-plans/) 때문으로 보입니다.

* 프로젝트에서 페이지네이션을 위해 `mongoose-paginate-v2` 를 사용하는데요, 내부 코드를 살펴보면 `mongodb`의 `skip, limit` 기능을 이용하여 페이지네이션을 수행하는 것을 확인하였습니다. 정렬 옵션이 있는 경우 정렬을 가장 먼저 수행하고요 이후에 skip, limit 파이프라인을 따라갑니다.
  * [참고](https://github.com/aravindnc/mongoose-paginate-v2/blob/9c1bb84ead9bb23e6cfcf6182094391dfd79b669/src/index.js#L189)

* 문제는 `createdAt` 필드를 기준으로 내림차순 정렬을 수행하는 곳에서 발생했습니다.
  * 현재 이벤트의 데이터들은 batch job으로 일괄적으로 db에 저장되었는데요, 그로 인해 중복된 값들이 다수 포진해있었습니다.
  * 이로 인해 [tie](https://www.mongodb.com/ko-kr/docs/drivers/go/v1.14/fundamentals/crud/read-operations/sort/#handling-ties)가 발생하였고, 도큐먼트간의 순서를 보장할 수 없었기 때문에 정렬단계에서 비일관성이 발생하였습니다.
<img width="541" alt="Screenshot 2024-12-18 at 03 14 56" src="https://github.com/user-attachments/assets/6646cef4-4c07-4b78-a0a3-a12cb9f95521" />

✅ `이벤트 시작일자, 종료일자` 를 기준으로 sorting 기준을 추가하여 tie를 제거하였습니다.