### PR TITLE
fix: react native config type to string

### DIFF
--- a/apps/app/react-native-config.d.ts
+++ b/apps/app/react-native-config.d.ts
@@ -1,8 +1,8 @@
 declare module 'react-native-config' {
     export interface NativeConfig {
+        DEBUG: string
         FE_URL: string
         BE_URL: string
-        DEBUG: boolean
     }
 
     export const Config: NativeConfig

--- a/apps/app/src/config/index.ts
+++ b/apps/app/src/config/index.ts
@@ -1,0 +1,6 @@
+import config from 'react-native-config'
+
+export const DEBUG = config.DEBUG === 'true'
+
+export const BE_URL = config.BE_URL
+export const FE_URL = config.FE_URL

--- a/apps/app/src/pages/Webview.tsx
+++ b/apps/app/src/pages/Webview.tsx
@@ -1,9 +1,8 @@
 import React from 'react'
-import config from 'react-native-config'
 import { WebView } from 'react-native-webview'
 
+import { DEBUG, FE_URL } from '../config'
+
 export default function WebviewScreen() {
-    return (
-        <WebView source={{ uri: config.FE_URL }} containerStyle={{ flex: 0, width: '100%', height: '100%' }} webviewDebuggingEnabled={config.DEBUG} />
-    )
+    return <WebView source={{ uri: FE_URL }} containerStyle={{ flex: 0, width: '100%', height: '100%' }} webviewDebuggingEnabled={DEBUG} />
 }


### PR DESCRIPTION
react native config 에서 사용하는 type 을 string 으로 변경합니다