### PR TITLE
fix: resolve conflicts between default config and .env variables, and prevent duplicate RNCConfigModule loading in Windows environment

### DIFF
--- a/apps/app/android/app/src/main/java/com/app/MainApplication.kt
+++ b/apps/app/android/app/src/main/java/com/app/MainApplication.kt
@@ -21,7 +21,6 @@ class MainApplication : Application(), ReactApplication {
             PackageList(this).packages.apply {
               // Packages that cannot be autolinked yet can be added manually here, for example:
               // add(MyReactNativePackage())
-              add(RNCConfigPackage())
             }
 
         override fun getJSMainModuleName(): String = "index"

--- a/apps/app/react-native-config.d.ts
+++ b/apps/app/react-native-config.d.ts
@@ -1,6 +1,6 @@
 declare module 'react-native-config' {
     export interface NativeConfig {
-        DEBUG: string
+        ENV: string
         FE_URL: string
         BE_URL: string
     }

--- a/apps/app/src/config/index.ts
+++ b/apps/app/src/config/index.ts
@@ -1,6 +1,6 @@
 import config from 'react-native-config'
 
-export const DEBUG = config.DEBUG === 'true'
+export const ENV = config.ENV === 'develop'
 
 export const BE_URL = config.BE_URL
 export const FE_URL = config.FE_URL

--- a/apps/app/src/pages/Webview.tsx
+++ b/apps/app/src/pages/Webview.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { WebView } from 'react-native-webview'
 
-import { DEBUG, FE_URL } from '../config'
+import { ENV, FE_URL } from '../config'
 
 export default function WebviewScreen() {
-    return <WebView source={{ uri: FE_URL }} containerStyle={{ flex: 0, width: '100%', height: '100%' }} webviewDebuggingEnabled={DEBUG} />
+    return <WebView source={{ uri: FE_URL }} containerStyle={{ flex: 0, width: '100%', height: '100%' }} webviewDebuggingEnabled={ENV} />
 }


### PR DESCRIPTION
window 환경에서 빌드 시 config의 DEBUG 값이 이미 사용되는 이름이기 때문에 빌드 오류가 발생하였습니다.

이를 해결하기 위해 DEBUG 값을 ENV 값으로 교체하는 작업입니다. 또한 window 환경에서 RNCConfigModule이 두 번 호출되는 경우로 인해 발생하는 실행 오류도 해결을 진행합니다.