### PR TITLE
refactor: separate main content from header and navigation

### DIFF
--- a/apps/web/src/app/(backButton)/layout.tsx
+++ b/apps/web/src/app/(backButton)/layout.tsx
@@ -3,9 +3,9 @@ import { PageTitleHeader } from '@/components/header'
 
 export default function BackButtonLayout({ children }: { children: React.ReactNode }) {
     return (
-        <div className="w-full h-full">
+        <div className="grid w-full h-screen">
             <PageTitleHeader />
-            <div className="w-full h-full">{children}</div>
+            <div className="w-full h-full overflow-y-scroll">{children}</div>
         </div>
     )
 }

--- a/apps/web/src/app/(navigation)/layout.tsx
+++ b/apps/web/src/app/(navigation)/layout.tsx
@@ -4,9 +4,9 @@ import { Navigation } from '@/components/navigation'
 
 export default function NavigationLayout({ children }: { children: React.ReactNode }) {
     return (
-        <div className="w-full h-full">
+        <div className="grid w-full h-screen">
             <LogoHeader />
-            <div className="w-full h-full pb-36">{children}</div>
+            <div className="w-full h-full overflow-y-scroll">{children}</div>
             <Navigation />
         </div>
     )

--- a/apps/web/src/components/header/logo.tsx
+++ b/apps/web/src/components/header/logo.tsx
@@ -2,7 +2,7 @@ import { NotificationIcon, TextLogo } from '@/components/icon'
 
 export function LogoHeader() {
     return (
-        <div className="sticky top-0 left-0 flex flex-row items-center justify-between w-full pt-10 p-2 z-10 bg-white">
+        <div className="flex flex-row w-full items-center justify-between bg-white pt-10 p-2">
             <div className="ps-4">
                 <TextLogo width={150} height={48} />
             </div>

--- a/apps/web/src/components/header/pageTitle.tsx
+++ b/apps/web/src/components/header/pageTitle.tsx
@@ -15,7 +15,7 @@ export function PageTitleHeader() {
     }
 
     return (
-        <div className="sticky top-0 left-0 flex flex-row items-center w-full pt-10 p-2  z-10 bg-white">
+        <div className="flex flex-row items-center w-full bg-white pt-10 p-2">
             <button className="absolute z-1 ps-4" onClick={onClick}>
                 <BackButtonIcon width={30} height={30} />
             </button>

--- a/apps/web/src/components/navigation/navigation.tsx
+++ b/apps/web/src/components/navigation/navigation.tsx
@@ -21,7 +21,7 @@ export function Navigation() {
     const [isVisible, setIsVisible] = useState(false)
 
     return (
-        <div className="fixed flex flex-col items-center justify-center bottom-0 left-0 z-50 w-full">
+        <div className="flex flex-col items-center justify-center w-full">
             <div
                 className={`fixed grid grid-cols-2 w-48 h-48 z-30 bg-white rounded-full shadow-[0_-1px_4px_rgba(0,0,0,0.25)] transition-all duration-700 pb-16 ${isVisible ? 'opacity-100 -translate-y-16' : 'opacity-0 translate-y-10'}`}
             >


### PR DESCRIPTION
현재 layout에서 header와 navigation이 메인 컨텐츠 위에 위치하고 있었습니다. 이 방식의 구조가 아닌 3개의 영역을 독립적으로 구분하기 위해 수정을 진행합니다.

# (navigation)/layout.tsx

![image](https://github.com/user-attachments/assets/44336972-f9cd-4bb1-9d44-c8cec0b22b3e)

# (backButton)/layout.tsx
![image](https://github.com/user-attachments/assets/67dd428a-2fe0-405d-9aa5-96615bb2716f)

