### PR TITLE
fix: update mainActivity.kt to reflect app name change

### DIFF
--- a/apps/app/android/app/src/main/java/com/app/MainActivity.kt
+++ b/apps/app/android/app/src/main/java/com/app/MainActivity.kt
@@ -12,7 +12,7 @@ class MainActivity : ReactActivity() {
    * Returns the name of the main component registered from JavaScript. This is used to schedule
    * rendering of the component.
    */
-  override fun getMainComponentName(): String = "app"
+  override fun getMainComponentName(): String = "Fienmee"
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(null)
   }


### PR DESCRIPTION
#64 변경 이후 react native가 실행되지 않는 오류를 해결하기 위해 app name 변경 사항을 android에 추가합니다.  

mac환경에서도 정상동작되는지 확인이 필요합니다.