### PR TITLE
fix: resolve Reflect.getMetadata is not function error in typegoose

### DIFF
--- a/apps/server/src/controllers/v1/users.ts
+++ b/apps/server/src/controllers/v1/users.ts
@@ -3,7 +3,7 @@ import express, { Request, Response, Router } from 'express'
 
 import { loginRequest, registerRequest } from '@/types/api'
 import { UnknownUserError } from '@/types/errors/oauth'
-import { User, UserModel } from '@/models/user'
+import { User, UserModel } from '@/models'
 import { issueJwt, getOAuthUser, expireJwt } from '@/services/oauth'
 
 const router: Router = asyncify(express.Router())

--- a/apps/server/src/models/enquiry.ts
+++ b/apps/server/src/models/enquiry.ts
@@ -1,10 +1,9 @@
 import mongoose from 'mongoose'
-import { getModelForClass, prop } from '@typegoose/typegoose'
-import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
+import { getModelForClass, prop, defaultClasses } from '@typegoose/typegoose'
 
 import { User } from '@/models'
 
-export class Enquiry extends TimeStamps {
+export class Enquiry extends defaultClasses.TimeStamps {
     public _id: mongoose.Types.ObjectId
 
     @prop({ required: true, ref: User })

--- a/apps/server/src/models/event.ts
+++ b/apps/server/src/models/event.ts
@@ -1,12 +1,11 @@
-import { getModelForClass, plugin, prop, ReturnModelType } from '@typegoose/typegoose'
+import { getModelForClass, plugin, prop, ReturnModelType, defaultClasses } from '@typegoose/typegoose'
 import mongoose from 'mongoose'
-import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
 import mongoosePaginate from 'mongoose-paginate-v2'
 
 import { User } from '@/models'
 
 @plugin(mongoosePaginate)
-export class Events extends TimeStamps {
+export class Events extends defaultClasses.TimeStamps {
     static paginate: mongoose.PaginateModel<typeof Events>['paginate']
 
     public _id: mongoose.Types.ObjectId

--- a/apps/server/src/models/index.ts
+++ b/apps/server/src/models/index.ts
@@ -1,5 +1,5 @@
 export * from './user'
-export * from './schedule'
 export * from './event'
+export * from './schedule'
 export * from './enquiry'
 export * from './connector'

--- a/apps/server/src/models/schedule.ts
+++ b/apps/server/src/models/schedule.ts
@@ -1,12 +1,11 @@
-import { getModelForClass, plugin, prop, ReturnModelType } from '@typegoose/typegoose'
+import { getModelForClass, plugin, prop, ReturnModelType, defaultClasses } from '@typegoose/typegoose'
 import mongoosePaginate from 'mongoose-paginate-v2'
 import mongoose from 'mongoose'
-import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
 
 import { User, Events } from '@/models'
 
 @plugin(mongoosePaginate)
-export class Schedule extends TimeStamps {
+export class Schedule extends defaultClasses.TimeStamps {
     static paginate: mongoose.PaginateModel<typeof Schedule>['paginate']
 
     public _id: mongoose.Types.ObjectId

--- a/apps/server/src/models/user.ts
+++ b/apps/server/src/models/user.ts
@@ -1,9 +1,8 @@
 import mongoose from 'mongoose'
-import { TimeStamps } from '@typegoose/typegoose/lib/defaultClasses'
-import { getModelForClass, prop, ReturnModelType } from '@typegoose/typegoose'
+import { getModelForClass, prop, ReturnModelType, defaultClasses } from '@typegoose/typegoose'
 import { IUser } from '@/types/oauth'
 
-export class User extends TimeStamps implements IUser {
+export class User extends defaultClasses.TimeStamps implements IUser {
     public _id: mongoose.Types.ObjectId
 
     @prop({ required: true })


### PR DESCRIPTION
#68 이후 생긴 이슈를 해결하기 위한 작업입니다.

typegoose에서 reflect-metadata 라이브러리와 관련된 이슈로, index.ts 파일로 인해 문제가 생긴 것으로 파악됩니다. 

정확한 오류 원인은 파악되지 않았으나, `TimeStamp` class를 가져오는 과정에서 생긴 이슈로 파악됩니다. lib폴더의 파일에서 직접 접근하는 것이 아니라 typegoose에서 접근하도록 수정함으로 해결되었습니다.

다른 방법으로는 저희 프로젝트에 reflect-metadata 라이브러리를 설치한 후 index.ts 파일에서 import하는 방법이 있었습니다.
