### PR TITLE
fix: preserve category information when navigating back from event detail page

### DIFF
--- a/apps/web/src/app/(backButton)/events/detail/page.tsx
+++ b/apps/web/src/app/(backButton)/events/detail/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { eventStore } from '@/store/event'
+import { eventStore } from '@/store'
 import EventDetail from '@/components/events/eventDetail'
 export default function Page() {
     const { event } = eventStore()

--- a/apps/web/src/components/events/categoryItem.tsx
+++ b/apps/web/src/components/events/categoryItem.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 
 import { BaseCategoryIcon, HottestCategoryIcon, WrittenCategoryIcon } from '@/components/icon'
-import { categoryStore } from '@/store'
+import { categoryStore, titleStore } from '@/store'
 
 interface Props {
     category: string
@@ -12,8 +12,10 @@ interface Props {
 
 export function CategoryItem({ category, isFavorites }: Props) {
     const { setCategory } = categoryStore()
+    const { setTitle } = titleStore()
     const onClick = () => {
         setCategory(category)
+        setTitle(category)
     }
     // TODO: change category names
     if (category === '내가 등록한 행사') {

--- a/apps/web/src/components/events/event.tsx
+++ b/apps/web/src/components/events/event.tsx
@@ -1,6 +1,7 @@
 import { IEvent } from '@fienmee/types'
 import Link from 'next/link'
 import { eventStore } from '@/store/event'
+import { titleStore } from '@/store'
 
 interface Props {
     event: IEvent | undefined
@@ -30,12 +31,17 @@ export default function Event({ event }: Props) {
     }
 
     const { setEvent } = eventStore()
+    const { setTitle } = titleStore()
+    const onClick = () => {
+        setEvent(event)
+        setTitle('')
+    }
 
     return (
         <Link
             href={`/events/detail`}
-            onClick={() => setEvent(event)}
-            className="block hover:bg-gray-100 transition duration-300 flex justify-between items-start gap-4 px-4 mb-12"
+            onClick={onClick}
+            className="flex hover:bg-gray-100 transition duration-300 justify-between items-start gap-4 px-4 mb-12"
         >
             <div className="flex flex-col w-2/3 ps-2 pt-2 gap-2">
                 <div className="text-xl font-semibold">{event.name}</div>

--- a/apps/web/src/components/header/pageTitle.tsx
+++ b/apps/web/src/components/header/pageTitle.tsx
@@ -2,16 +2,22 @@
 
 import { useRouter } from 'next/navigation'
 
-import { categoryStore } from '@/store'
+import { categoryStore, titleStore } from '@/store'
 import { BackButtonIcon } from '@/components/icon'
 
 export function PageTitleHeader() {
     const router = useRouter()
+    const { title, setTitle } = titleStore()
     const { category, setCategory } = categoryStore()
 
     const onClick = () => {
+        if (!title && category) {
+            setTitle(category)
+        } else {
+            setTitle('')
+            setCategory('')
+        }
         router.back()
-        setCategory('')
     }
 
     return (
@@ -19,7 +25,7 @@ export function PageTitleHeader() {
             <button className="absolute z-1 ps-4" onClick={onClick}>
                 <BackButtonIcon width={30} height={30} />
             </button>
-            <span className="text-3xl text-center font-semibold w-full">{category}</span>
+            <span className="text-3xl text-center font-semibold w-full">{title}</span>
         </div>
     )
 }

--- a/apps/web/src/store/category.ts
+++ b/apps/web/src/store/category.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand'
 
 interface CategoryStore {
     category: string
-    setCategory: (name: string) => void
+    setCategory: (category: string) => void
 }
 
 export const categoryStore = create<CategoryStore>(set => ({

--- a/apps/web/src/store/index.ts
+++ b/apps/web/src/store/index.ts
@@ -1,1 +1,3 @@
 export * from './category'
+export * from './event'
+export * from './title'

--- a/apps/web/src/store/title.ts
+++ b/apps/web/src/store/title.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand'
+
+interface TitleStore {
+    title: string
+    setTitle: (title: string) => void
+}
+
+export const titleStore = create<TitleStore>(set => ({
+    title: '',
+    setTitle: title => {
+        set({ title })
+    },
+}))


### PR DESCRIPTION
event detail 페이지에서 뒤로가기 버튼을 누르는 경우 category 정보가 모두 삭제되어 category 페이지가 정상동작하지 않는 오류를 해결합니다. 
+ title과 category를 분리합니다. 
+ figma에 따라 detail page로 이동할 때 title이 없도록 변경합니다. 