### PR TITLE
feat: add event update action to option button

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -24,9 +24,10 @@ router.get('/categories', async (req: Request, res: Response) => {
     })
 })
 
-router.post('/', async (req: Request, res: Response) => {
+router.post('/', verifyToken, async (req: Request, res: Response) => {
     await EventsModel.create({
         name: req.body.name,
+        authorId: req.user._id,
         location: req.body.location,
         startDate: req.body.startDate,
         endDate: req.body.endDate,
@@ -80,8 +81,7 @@ router.get('/category/:category', verifyToken, async (req: Request, res: Respons
         // TODO: add get hottest events
         result = await EventsModel.findByCategory(category._id, options)
     }
-
-    const events = result.docs.map(event => ({ ...event.toJSON() }))
+    const events = result.docs.map(event => ({ ...event.toJSON(), isAuthor: event.get('authorId')?.equals(req.user._id) }))
 
     res.status(200).json({
         events: events,

--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -58,10 +58,10 @@ router.delete('/:id', async (req: Request, res: Response) => {
     res.sendStatus(200)
 })
 
-router.get('/:id', async (req: Request, res: Response) => {
+router.get('/:id', verifyToken, async (req: Request, res: Response) => {
     const event = await EventsModel.findById(req.params.id)
 
-    res.status(200).json(event)
+    res.status(200).json({ ...event, isAuthor: event.authorId.equals(req.user._id) })
 })
 
 router.get('/category/:category', verifyToken, async (req: Request, res: Response) => {

--- a/apps/web/src/api/event.ts
+++ b/apps/web/src/api/event.ts
@@ -1,4 +1,4 @@
-import { IEvent, IGetEventCategoriesResponse, IGetEventsByCategoryResponse } from '@fienmee/types'
+import { IEvent, IGetEventCategoriesResponse, IGetEventsByCategoryResponse, IPutEventRequest } from '@fienmee/types'
 
 import { SERVER_URL } from '@/config'
 
@@ -51,6 +51,21 @@ export async function registerEvent(eventData: IEvent): Promise<void> {
         body: JSON.stringify(eventData),
     })
 
+    if (!res.ok) {
+        throw new Error(`code: ${res.status}\ndescription: ${res.statusText}`)
+    }
+    return
+}
+
+export async function updateEvent(request: IPutEventRequest): Promise<void> {
+    const res = await fetch(`${SERVER_URL}/v1/events/${request.uri._id}`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+            // TODO: add authorization Header
+        },
+        body: JSON.stringify(request.body),
+    })
     if (!res.ok) {
         throw new Error(`code: ${res.status}\ndescription: ${res.statusText}`)
     }

--- a/apps/web/src/api/event.ts
+++ b/apps/web/src/api/event.ts
@@ -42,11 +42,12 @@ export async function deleteEventById(id: string): Promise<void> {
 }
 
 export async function registerEvent(eventData: IEvent): Promise<void> {
+    const token = sessionStorage.getItem('access_token')
     const res = await fetch(`${SERVER_URL}/v1/events`, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            // TODO: add authorization Header
+            Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(eventData),
     })

--- a/apps/web/src/api/event.ts
+++ b/apps/web/src/api/event.ts
@@ -58,11 +58,12 @@ export async function registerEvent(eventData: IEvent): Promise<void> {
 }
 
 export async function updateEvent(request: IPutEventRequest): Promise<void> {
+    const token = sessionStorage.getItem('access_token')
     const res = await fetch(`${SERVER_URL}/v1/events/${request.uri._id}`, {
         method: 'PUT',
         headers: {
             'Content-Type': 'application/json',
-            // TODO: add authorization Header
+            Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify(request.body),
     })

--- a/apps/web/src/app/(backButton)/events/register/page.tsx
+++ b/apps/web/src/app/(backButton)/events/register/page.tsx
@@ -31,7 +31,14 @@ function RegisterPageContent() {
 
     useEffect(() => {
         if (category) {
-            setSelectedCategories(prev => new Set(prev).add(JSON.parse(category)))
+            const parsedCategory = JSON.parse(category)
+            setSelectedCategories(prev => {
+                const newSet = new Set(prev)
+                if (![...newSet].some(cat => cat._id === parsedCategory._id)) {
+                    newSet.add(parsedCategory)
+                }
+                return newSet
+            })
         }
     }, [category])
 

--- a/apps/web/src/app/(backButton)/events/update/page.tsx
+++ b/apps/web/src/app/(backButton)/events/update/page.tsx
@@ -1,3 +1,42 @@
+'use client'
+
+import PhotoUploader from '@/components/events/photoUploader'
+import EventForm from '@/components/events/eventForm'
+import { useEffect, useState } from 'react'
+import { eventStore } from '@/store'
+
 export default function EventUpdate() {
-    return <div className="grid items-center justify-items-center min-h-screen">Event Update</div>
+    const { event, setEvent } = eventStore()
+    const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set())
+    const [isAllDay, setIsAllDay] = useState(false)
+    const category = event.category
+    const handleAddPhoto = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const files = Array.from(e.target.files || [])
+        const newPhotos = files.map(file => URL.createObjectURL(file))
+        setEvent({ ...event, photo: [...event.photo, ...newPhotos] })
+        e.target.value = ''
+    }
+
+    useEffect(() => {
+        if (category) {
+            setSelectedCategories(prev => new Set([...prev, ...category]))
+        }
+    }, [category])
+
+    const handleRemovePhoto = (index: number) => {
+        setEvent({ ...event, photo: event.photo.filter((_, i) => i !== index) })
+    }
+
+    return (
+        <div className="grid items-center justify-items-center min-h-screen">
+            <PhotoUploader photos={event.photo} onAddPhoto={handleAddPhoto} onRemovePhoto={handleRemovePhoto} />
+            <EventForm
+                isAllDay={isAllDay}
+                toggleAllDay={() => setIsAllDay(!isAllDay)}
+                selectedCategories={selectedCategories}
+                photos={event.photo}
+                initEvent={event}
+            />
+        </div>
+    )
 }

--- a/apps/web/src/app/(backButton)/events/update/page.tsx
+++ b/apps/web/src/app/(backButton)/events/update/page.tsx
@@ -4,10 +4,11 @@ import PhotoUploader from '@/components/events/photoUploader'
 import EventForm from '@/components/events/eventForm'
 import { useEffect, useState } from 'react'
 import { eventStore } from '@/store'
+import { ICategory } from '@fienmee/types'
 
 export default function EventUpdate() {
     const { event, setEvent } = eventStore()
-    const [selectedCategories, setSelectedCategories] = useState<Set<string>>(new Set())
+    const [selectedCategories, setSelectedCategories] = useState<Set<ICategory>>(new Set())
     const [isAllDay, setIsAllDay] = useState(false)
     const category = event.category
     const handleAddPhoto = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/web/src/app/(backButton)/events/update/page.tsx
+++ b/apps/web/src/app/(backButton)/events/update/page.tsx
@@ -8,7 +8,7 @@ import { ICategory } from '@fienmee/types'
 
 export default function EventUpdate() {
     const { event, setEvent } = eventStore()
-    const [selectedCategories, setSelectedCategories] = useState<Set<ICategory>>(new Set())
+    const [selectedCategories, setSelectedCategories] = useState<Set<ICategory>>(new Set(event.category))
     const [isAllDay, setIsAllDay] = useState(false)
     const category = event.category
     const handleAddPhoto = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/web/src/components/events/dateTimeInput.tsx
+++ b/apps/web/src/components/events/dateTimeInput.tsx
@@ -2,13 +2,14 @@ import React, { useState } from 'react'
 
 interface DateTimeInputProps {
     label: string
+    value: Date
     onChange: (dateTime: string) => void
     hideTime?: boolean
 }
 
-const DateTimeInput: React.FC<DateTimeInputProps> = ({ label, onChange, hideTime }) => {
-    const [date, setDate] = useState('')
-    const [time, setTime] = useState('')
+const DateTimeInput: React.FC<DateTimeInputProps> = ({ label, value, onChange, hideTime }) => {
+    const [date, setDate] = useState(new Date(value).toISOString().split('T')[0])
+    const [time, setTime] = useState(new Date(value).toTimeString().slice(0, 5))
 
     const handleDateChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const newDate = e.target.value
@@ -26,8 +27,8 @@ const DateTimeInput: React.FC<DateTimeInputProps> = ({ label, onChange, hideTime
         <div className="flex justify-between items-center gap-2">
             <label className="text-sm text-gray-700">{label}</label>
             <div className="flex gap-2">
-                <input type="date" className="border rounded px-2 py-1" onChange={handleDateChange} />
-                {!hideTime && <input type="time" className="border rounded px-2 py-1" onChange={handleTimeChange} />}
+                <input type="date" value={date} className="border rounded px-2 py-1" onChange={handleDateChange} />
+                {!hideTime && <input type="time" value={time} className="border rounded px-2 py-1" onChange={handleTimeChange} />}
             </div>
         </div>
     )

--- a/apps/web/src/components/events/eventDetail.tsx
+++ b/apps/web/src/components/events/eventDetail.tsx
@@ -27,9 +27,7 @@ export default function EventDetail({ event }: Props) {
             <div className="flex flex-col p-4 space-y-4">
                 <div className="flex justify-between items-start">
                     <div className="text-xl font-bold">{event.name}</div>
-                    <div className="relative">
-                        <EventOption eventId={event._id} />
-                    </div>
+                    <div className="relative">{event.isAuthor && <EventOption eventId={event._id} />}</div>
                 </div>
 
                 <div className="space-y-4">

--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -3,49 +3,63 @@ import EventTimeSelector from '@/components/events/eventTimeSelector'
 import InputField from '@/components/events/inputField'
 import SubmitButton from './submitButton'
 import EventVenueSelector from './eventVenueSelector'
-import { registerEvent } from '@/api/event'
+import { registerEvent, updateEvent } from '@/api/event'
 import { IEvent } from '@fienmee/types'
 import { useRouter } from 'next/navigation'
 import { ArrowIcon } from '../icon/icon'
+import {eventStore} from "@/store";
 
 interface EventFormProps {
     isAllDay: boolean
     toggleAllDay: () => void
     selectedCategories: Set<string>
     photos: string[]
+    initEvent?: IEvent
 }
 
-const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedCategories, photos }) => {
+const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedCategories, photos, initEvent }) => {
     const router = useRouter()
+    const { setEvent } = eventStore()
     console.log(photos)
     const handleCategorySelect = () => {
         router.push('/events/register/category')
     }
 
-    const [position, setPosition] = useState({ lat: 33.450701, lng: 126.570667 })
-    const [formData, setFormData] = useState<IEvent>({
-        _id: '',
-        name: '',
-        address: '',
-        location: {
-            type: 'Point',
-            coordinates: [126.570667, 33.450701],
+    const [position, setPosition] = useState(
+        initEvent ? { lat: initEvent.location.coordinates[1], lng: initEvent.location.coordinates[0] } : { lat: 33.450701, lng: 126.570667 },
+    )
+    const [formData, setFormData] = useState<IEvent>(
+        initEvent || {
+            _id: '',
+            name: '',
+            address: '',
+            location: {
+                type: 'Point',
+                coordinates: [126.570667, 33.450701],
+            },
+            startDate: new Date(),
+            endDate: new Date(),
+            description: '',
+            photo: [],
+            cost: '',
+            likeCount: 0,
+            commentCount: 0,
+            category: [],
+            targetAudience: [],
+            createdAt: new Date(),
         },
-        startDate: new Date(),
-        endDate: new Date(),
-        description: '',
-        photo: [],
-        cost: '',
-        likeCount: 0,
-        commentCount: 0,
-        category: [],
-        targetAudience: [],
-        createdAt: new Date(),
-    })
+    )
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target
-        setFormData(prevState => ({ ...prevState, [name]: value }))
+        if (name === 'targetAudience') {
+            setFormData(prevState => ({
+                ...prevState,
+                [name]: value ? [value] : []
+            }))
+        } else {
+            setFormData(prevState => ({ ...prevState, [name]: value }))
+        }
     }
 
     const onStartDateTimeChange = (dateTime: string) => {
@@ -59,17 +73,36 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault()
         console.log(formData)
+
         try {
-            await registerEvent({
-                ...formData,
-                category: Array.from(selectedCategories),
-                photo: photos,
-                location: {
-                    type: 'Point',
-                    coordinates: [position.lng, position.lat],
-                },
-            })
-            alert('이벤트가 성공적으로 등록되었습니다.')
+            if (initEvent) {
+                await updateEvent({
+                    body: {
+                        ...formData,
+                        category: Array.from(selectedCategories),
+                        photo: photos,
+                        location: {
+                            type: 'Point',
+                            coordinates: [position.lng, position.lat],
+                        },
+                    },
+                    uri: { _id: initEvent._id },
+                })
+                alert('이벤트가 성공적으로 수정되었습니다.')
+                setEvent(formData)
+                router.push('/events/detail')
+            } else {
+                await registerEvent({
+                    ...formData,
+                    category: Array.from(selectedCategories),
+                    photo: photos,
+                    location: {
+                        type: 'Point',
+                        coordinates: [position.lng, position.lat],
+                    },
+                })
+                alert('이벤트가 성공적으로 등록되었습니다.')
+            }
         } catch (error) {
             console.error('이벤트 등록 실패:', error)
             alert('이벤트 등록에 실패했습니다.')
@@ -78,7 +111,7 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
 
     return (
         <form className="p-6 w-full max-w-lg mx-auto flex flex-col gap-6" onSubmit={handleSubmit}>
-            <InputField label="행사 제목" placeholder="행사 제목을 입력해주세요" name="name" onChange={handleChange} />
+            <InputField label="행사 제목" placeholder="행사 제목을 입력해주세요" value={formData.name} name="name" onChange={handleChange} />
             <div className="flex items-center">
                 <label className="mr-2">카테고리</label>
                 <div className="flex flex-wrap gap-2">
@@ -102,11 +135,18 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
                 <label>행사 장소</label>
                 <EventVenueSelector initialPosition={position} onPositionChange={setPosition} />
             </div>
-            <InputField label="이용 요금" placeholder="₩ 이용 요금을 입력해주세요" name="cost" onChange={handleChange} />
-            <InputField label="이용 대상" placeholder="이용 대상을 입력해주세요" name="targetAudience" onChange={handleChange} />
+            <InputField label="이용 요금" placeholder="₩ 이용 요금을 입력해주세요" value={formData.cost} name="cost" onChange={handleChange} />
+            <InputField
+                label="이용 대상"
+                placeholder="이용 대상을 입력해주세요"
+                value={formData.targetAudience?.[0]}
+                name="targetAudience"
+                onChange={handleChange}
+            />
             <InputField
                 label="설명"
                 placeholder="행사에 대한 설명을 작성해주세요"
+                value={formData.description}
                 type="textarea"
                 rows={4}
                 name="description"

--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -65,11 +65,11 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
     }
 
     const onStartDateTimeChange = (dateTime: string) => {
-        setFormData(prevState => ({ ...prevState, startDateTime: dateTime }))
+        setFormData(prevState => ({ ...prevState, startDate: new Date(dateTime) }))
     }
 
     const onEndDateTimeChange = (dateTime: string) => {
-        setFormData(prevState => ({ ...prevState, endDateTime: dateTime }))
+        setFormData(prevState => ({ ...prevState, endDate: new Date(dateTime) }))
     }
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -130,6 +130,8 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
             <EventTimeSelector
                 isAllDay={isAllDay}
                 toggleAllDay={toggleAllDay}
+                initStartDate={formData.startDate}
+                initEndDate={formData.endDate}
                 onStartDateChange={onStartDateTimeChange}
                 onEndDateChange={onEndDateTimeChange}
             />

--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -8,7 +8,7 @@ import { registerEvent, updateEvent } from '@/api/event'
 import { ICategory, IEvent } from '@fienmee/types'
 import { useRouter } from 'next/navigation'
 import { ArrowIcon } from '../icon/icon'
-import {eventStore} from "@/store";
+import { eventStore } from '@/store'
 
 interface EventFormProps {
     isAllDay: boolean
@@ -48,6 +48,7 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
             category: [],
             targetAudience: [],
             createdAt: new Date(),
+            isAuthor: false,
         },
     )
 
@@ -56,7 +57,7 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
         if (name === 'targetAudience') {
             setFormData(prevState => ({
                 ...prevState,
-                [name]: value ? [value] : []
+                [name]: value ? [value] : [],
             }))
         } else {
             setFormData(prevState => ({ ...prevState, [name]: value }))

--- a/apps/web/src/components/events/eventOption.tsx
+++ b/apps/web/src/components/events/eventOption.tsx
@@ -4,6 +4,7 @@ import { OptionIcon } from '@/components/icon'
 import { useRouter } from 'next/navigation'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { deleteEventById } from '@/api/event'
+import Link from 'next/link'
 
 export default function EventOption({ eventId }: { eventId: string }) {
     const router = useRouter()
@@ -24,7 +25,9 @@ export default function EventOption({ eventId }: { eventId: string }) {
     return (
         <Dropdown Icon={OptionIcon} xTranslate={'-translate-x-20'}>
             {/* TODO: add modify function */}
-            <button className="w-24 p-3 border-b border-gray-200">수정하기</button>
+            <Link className="w-24 p-3 border-b border-gray-200" href={'/events/update'}>
+                수정하기
+            </Link>
             <button className="w-24 p-3" onClick={handleDelete}>
                 삭제하기
             </button>

--- a/apps/web/src/components/events/eventTimeSelector.tsx
+++ b/apps/web/src/components/events/eventTimeSelector.tsx
@@ -4,11 +4,20 @@ import DateTimeInput from './dateTimeInput'
 interface EventTimeSelectorProps {
     isAllDay: boolean
     toggleAllDay: () => void
+    initStartDate: Date
+    initEndDate: Date
     onStartDateChange: (date: string) => void
     onEndDateChange: (date: string) => void
 }
 
-const EventTimeSelector: React.FC<EventTimeSelectorProps> = ({ isAllDay, toggleAllDay, onStartDateChange, onEndDateChange }) => {
+const EventTimeSelector: React.FC<EventTimeSelectorProps> = ({
+    isAllDay,
+    toggleAllDay,
+    initStartDate,
+    initEndDate,
+    onStartDateChange,
+    onEndDateChange,
+}) => {
     return (
         <div>
             <label className="block text-base font-medium mb-2">행사 시간</label>
@@ -26,8 +35,8 @@ const EventTimeSelector: React.FC<EventTimeSelectorProps> = ({ isAllDay, toggleA
                 <hr className="border-gray-300 mb-4" />
 
                 <div className="flex flex-col gap-3">
-                    <DateTimeInput label="시작" onChange={onStartDateChange} hideTime={isAllDay} />
-                    <DateTimeInput label="종료" onChange={onEndDateChange} hideTime={isAllDay} />
+                    <DateTimeInput label="시작" value={initStartDate} onChange={onStartDateChange} hideTime={isAllDay} />
+                    <DateTimeInput label="종료" value={initEndDate} onChange={onEndDateChange} hideTime={isAllDay} />
                 </div>
             </div>
         </div>

--- a/apps/web/src/components/events/inputField.tsx
+++ b/apps/web/src/components/events/inputField.tsx
@@ -6,17 +6,32 @@ interface InputFieldProps {
     type?: string
     rows?: number
     name: string
+    value?: string
     onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
 }
 
-const InputField: React.FC<InputFieldProps> = ({ label, placeholder, type = 'text', rows, name, onChange }) => {
+const InputField: React.FC<InputFieldProps> = ({ label, placeholder, type = 'text', rows, name, value, onChange }) => {
     return (
         <div>
             <label className="block text-base font-medium mb-2">{label}</label>
             {type === 'textarea' ? (
-                <textarea name={name} placeholder={placeholder} className="w-full border rounded-lg px-4 py-2" rows={rows} onChange={onChange} />
+                <textarea
+                    name={name}
+                    placeholder={placeholder}
+                    className="w-full border rounded-lg px-4 py-2"
+                    rows={rows}
+                    value={value}
+                    onChange={onChange}
+                />
             ) : (
-                <input type={type} name={name} placeholder={placeholder} className="w-full border rounded-lg px-4 py-2" onChange={onChange} />
+                <input
+                    type={type}
+                    name={name}
+                    placeholder={placeholder}
+                    className="w-full border rounded-lg px-4 py-2"
+                    value={value}
+                    onChange={onChange}
+                />
             )}
         </div>
     )

--- a/apps/web/src/store/event.ts
+++ b/apps/web/src/store/event.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { IEvent } from '@fienmee/types'
+import { ICategory, IEvent } from '@fienmee/types'
 
 interface eventState {
     event: IEvent
@@ -22,7 +22,7 @@ export const eventStore = create<eventState>(set => ({
         cost: '',
         likeCount: 0,
         commentCount: 0,
-        category: [],
+        category: [] as ICategory[],
         targetAudience: [],
         createdAt: new Date(),
         isAuthor: false,

--- a/apps/web/src/store/event.ts
+++ b/apps/web/src/store/event.ts
@@ -25,6 +25,7 @@ export const eventStore = create<eventState>(set => ({
         category: [],
         targetAudience: [],
         createdAt: new Date(),
+        isAuthor: false,
     },
     setEvent: event => {
         set({ event })

--- a/packages/types/api/events.ts
+++ b/packages/types/api/events.ts
@@ -18,6 +18,7 @@ export interface IEvent {
     category: ICategory[]
     targetAudience: string[]
     createdAt: Date
+    isAuthor: boolean
 }
 
 export interface IGetEventsByCategoryResponse {
@@ -30,11 +31,6 @@ export interface IGetEventsByCategoryResponse {
         limit: number
     }
     events: IEvent[]
-}
-
-export interface IGetEventCategoriesResponse {
-    categories: string[]
-    favoriteCategories: string[]
 }
 
 export interface IPutEventRequest {
@@ -59,5 +55,4 @@ export interface IPutEventRequest {
     uri: {
         _id: string
     }
-    // TODO : add token
 }

--- a/packages/types/api/events.ts
+++ b/packages/types/api/events.ts
@@ -34,3 +34,28 @@ export interface IGetEventCategoriesResponse {
     categories: string[]
     favoriteCategories: string[]
 }
+
+export interface IPutEventRequest {
+    body: {
+        name: string
+        address: string
+        location: {
+            type: string
+            coordinates: number[]
+        }
+        startDate: Date
+        endDate: Date
+        description: string
+        photo: string[]
+        cost: string
+        likeCount: number
+        commentCount: number
+        category: string[]
+        targetAudience: string[]
+        createdAt: Date
+    }
+    uri: {
+        _id: string
+    }
+    // TODO : add token
+}

--- a/packages/types/api/events.ts
+++ b/packages/types/api/events.ts
@@ -48,7 +48,7 @@ export interface IPutEventRequest {
         cost: string
         likeCount: number
         commentCount: number
-        category: string[]
+        category: ICategory[]
         targetAudience: string[]
         createdAt: Date
     }


### PR DESCRIPTION
FE에서 이벤트 수정 기능을 추가하였습니다.
- 수정 버튼 클릭 시 update 페이지로 이동하도록 추가
- update 페이지 수정
- EventForm에서 수정 작업 추가, 기존 이벤트 데이터 사용하도록 추가
- InputField에서 기존 이벤트 값 노출 되도록 추가


추가로, targetAudience가 string 배열인데 string 타입으로 변경하는건 어떤지 의견을 들어보고 싶습니다! 배열에 단일 값으로 DB에 저장이 되는 것 같은데 단일 값만 있으면 굳이 배열로 하지 않아도 될 것 같아서요.