### PR TITLE
refactor: [FE] change types of category in eventForm

### DIFF
--- a/apps/web/src/api/event.ts
+++ b/apps/web/src/api/event.ts
@@ -1,4 +1,4 @@
-import { IEvent, IGetEventCategoriesResponse, IGetEventsByCategoryResponse, IPutEventRequest } from '@fienmee/types'
+import { IGetEventCategoriesResponse, IGetEventsByCategoryResponse, IPostEventRequest, IPutEventRequest } from '@fienmee/types'
 
 import { SERVER_URL } from '@/config'
 
@@ -41,7 +41,7 @@ export async function deleteEventById(id: string): Promise<void> {
     return
 }
 
-export async function registerEvent(eventData: IEvent): Promise<void> {
+export async function registerEvent(eventData: IPostEventRequest): Promise<void> {
     const token = sessionStorage.getItem('access_token')
     const res = await fetch(`${SERVER_URL}/v1/events`, {
         method: 'POST',
@@ -49,7 +49,7 @@ export async function registerEvent(eventData: IEvent): Promise<void> {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
         },
-        body: JSON.stringify(eventData),
+        body: JSON.stringify(eventData.body),
     })
 
     if (!res.ok) {

--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -81,7 +81,7 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
                 await updateEvent({
                     body: {
                         ...formData,
-                        category: Array.from(selectedCategories),
+                        category: Array.from(selectedCategories).map(category => category._id),
                         photo: photos,
                         location: {
                             type: 'Point',
@@ -95,12 +95,14 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
                 router.push('/events/detail')
             } else {
                 await registerEvent({
-                    ...formData,
-                    category: Array.from(selectedCategories),
-                    photo: photos,
-                    location: {
-                        type: 'Point',
-                        coordinates: [position.lng, position.lat],
+                    body: {
+                        ...formData,
+                        category: Array.from(selectedCategories).map(category => category._id),
+                        photo: photos,
+                        location: {
+                            type: 'Point',
+                            coordinates: [position.lng, position.lat],
+                        },
                     },
                 })
                 alert('이벤트가 성공적으로 등록되었습니다.')

--- a/packages/types/api/events.ts
+++ b/packages/types/api/events.ts
@@ -33,7 +33,7 @@ export interface IGetEventsByCategoryResponse {
     events: IEvent[]
 }
 
-export interface IPutEventRequest {
+export interface IPostEventRequest {
     body: {
         name: string
         address: string
@@ -48,10 +48,13 @@ export interface IPutEventRequest {
         cost: string
         likeCount: number
         commentCount: number
-        category: ICategory[]
+        category: string[]
         targetAudience: string[]
         createdAt: Date
     }
+}
+
+export interface IPutEventRequest extends IPostEventRequest {
     uri: {
         _id: string
     }


### PR DESCRIPTION
이벤트를 등록하거나 수정할 때 카테고리 객체가 아닌 id 배열을 저장하도록 변경하였습니다.

현재 카테고리를 수정할 경우 입력했던 데이터가 사라지거나, 이벤트 수정 페이지에서 이벤트 등록 페이지로 이동해버려서 다른 이슈를 진행하면서 수정할 예정입니다.