### PR TITLE
feat: Implement account deactivation using Kakao unlink

### DIFF
--- a/apps/server/src/controllers/v1/users.ts
+++ b/apps/server/src/controllers/v1/users.ts
@@ -83,7 +83,7 @@ router.delete('/', verifyToken, async (req: Request, res: Response) => {
     await unlinkUser(req.user)
     expireJwt(jwt)
 
-    res.sendStatus(200)
+    res.sendStatus(204)
 })
 
 export default router

--- a/apps/server/src/controllers/v1/users.ts
+++ b/apps/server/src/controllers/v1/users.ts
@@ -16,7 +16,7 @@ router.post('/login', async (req: Request, res: Response) => {
 
     const oauthUser = await getOAuthUser(request)
     const user = await UserModel.findByProviderId(oauthUser.providerId)
-    if (!user) {
+    if (!user || user.isDeleted) {
         throw new UnknownUserError(new Error(`not found ${oauthUser.providerId}`))
     }
 

--- a/apps/server/src/controllers/v1/users.ts
+++ b/apps/server/src/controllers/v1/users.ts
@@ -5,9 +5,9 @@ import { loginRequest, loginResponse, refreshResponse, registerRequest, register
 
 import { UnknownUserError } from '@/types/errors/oauth'
 import { User, UserModel } from '@/models'
-import { issueAccessToken, getOAuthUser, expireJwt, issueRefreshToken } from '@/services/oauth'
-import { verifyToken } from '@/middlewares/auth'
 import { InvalidTokenTypeError } from '@/types/errors'
+import { issueAccessToken, getOAuthUser, expireJwt, issueRefreshToken, unlinkUser } from '@/services/oauth'
+import { verifyToken } from '@/middlewares/auth'
 
 const router: Router = asyncify(express.Router())
 
@@ -75,6 +75,15 @@ router.post('/refresh', verifyToken, async (req: Request, res: Response) => {
     }
 
     res.status(200).json(response)
+})
+
+router.delete('/', verifyToken, async (req: Request, res: Response) => {
+    const jwt = req.headers['authorization']?.split(' ')?.[1]
+
+    await unlinkUser(req.user)
+    expireJwt(jwt)
+
+    res.sendStatus(200)
 })
 
 export default router

--- a/apps/server/src/controllers/v1/users.ts
+++ b/apps/server/src/controllers/v1/users.ts
@@ -43,7 +43,7 @@ router.delete('/logout', async (req: Request, res: Response) => {
 
 router.post('/register', async (req: Request, res: Response) => {
     const request: registerRequest = req.body
-    console.log(request)
+
     const oauthUser = await getOAuthUser(request)
 
     const user = await registerUser(oauthUser)

--- a/apps/server/src/models/user.ts
+++ b/apps/server/src/models/user.ts
@@ -23,6 +23,9 @@ export class User extends defaultClasses.TimeStamps implements IUser {
     @prop({ default: Date.now() })
     public lastLoggedInAt: Date
 
+    @prop({ default: false })
+    public isDeleted: boolean
+
     public toJSON() {
         return {
             _id: this._id,
@@ -44,6 +47,10 @@ export class User extends defaultClasses.TimeStamps implements IUser {
             { _id: user._id },
             { accessToken: user.accessToken, refreshToken: user.refreshToken, lastLoggedInAt: Date.now() },
         ).exec()
+    }
+
+    public static async updateUserDeletionStatus(this: ReturnModelType<typeof User>, user: User) {
+        return await this.findOneAndUpdate({ _id: user._id }, { isDeleted: user.isDeleted }).exec()
     }
 }
 

--- a/apps/server/src/services/oauth/auth.ts
+++ b/apps/server/src/services/oauth/auth.ts
@@ -1,6 +1,7 @@
 import { ICredentials, IOAuth, IUser } from '@/types/oauth'
 import { Kakao } from '@/services/oauth/kakao'
 import { UnknownProviderError } from '@/types/errors/oauth'
+import { User, UserModel } from '@/models'
 
 export async function getOAuthUser(credential: ICredentials): Promise<IUser> {
     const provider = getOAuthProvider(credential.provider)
@@ -14,4 +15,12 @@ function getOAuthProvider(provider: string): IOAuth {
         default:
             throw new UnknownProviderError(provider)
     }
+}
+
+export async function unlinkUser(user: User): Promise<void> {
+    const provider = getOAuthProvider(user.provider)
+    await provider.unlinkUser(user)
+
+    user.isDeleted = true
+    await UserModel.updateUserDeletionStatus(user)
 }

--- a/apps/server/src/services/oauth/kakao.ts
+++ b/apps/server/src/services/oauth/kakao.ts
@@ -1,6 +1,6 @@
 import fetch from 'node-fetch'
 
-import { KakaoUserInformationError } from '@/types/errors'
+import { KakaoNetworkError, KakaoUserInformationError } from '@/types/errors'
 import { ICredentials, IOAuth, IUser, getUserMeResponse } from '@/types/oauth'
 
 export class Kakao implements IOAuth {
@@ -22,5 +22,17 @@ export class Kakao implements IOAuth {
             nickname: data.kakao_account.profile.nickname,
             providerId: data.id,
         }
+    }
+
+    public async unlinkUser(credential: ICredentials): Promise<void> {
+        await fetch('https://kapi.kakao.com/v1/user/unlink', {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${credential.accessToken}`,
+                'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+            },
+        }).catch(e => {
+            throw new KakaoNetworkError(e)
+        })
     }
 }

--- a/apps/server/src/services/user.ts
+++ b/apps/server/src/services/user.ts
@@ -1,0 +1,13 @@
+import { User, UserModel } from '@/models'
+import { IUser } from '@/types/oauth'
+
+export async function registerUser(oauthUser: IUser): Promise<User> {
+    let user = await UserModel.findByProviderId(oauthUser.providerId)
+    if (user && user.isDeleted) {
+        user.isDeleted = false
+        await UserModel.updateUserDeletionStatus(user)
+    } else if (!user) {
+        user = await UserModel.createUser(oauthUser)
+    }
+    return user
+}

--- a/apps/server/src/types/errors/oauth/auth.ts
+++ b/apps/server/src/types/errors/oauth/auth.ts
@@ -10,7 +10,7 @@ export class UnknownUserError extends APIError {
 
 export class DeletedUserError extends APIError {
     constructor(cause: Error | string = null) {
-        super(404, 4100, 'deleted user error', cause)
+        super(404, 4101, 'deleted user error', cause)
         Object.setPrototypeOf(this, DeletedUserError.prototype)
         Error.captureStackTrace(this, DeletedUserError)
     }

--- a/apps/server/src/types/errors/oauth/auth.ts
+++ b/apps/server/src/types/errors/oauth/auth.ts
@@ -8,6 +8,14 @@ export class UnknownUserError extends APIError {
     }
 }
 
+export class DeletedUserError extends APIError {
+    constructor(cause: Error | string = null) {
+        super(404, 4100, 'deleted user error', cause)
+        Object.setPrototypeOf(this, DeletedUserError.prototype)
+        Error.captureStackTrace(this, DeletedUserError)
+    }
+}
+
 export class UnknownProviderError extends APIError {
     constructor(cause: Error | string = null) {
         super(404, 4100, 'unknown oauth provider error', cause)

--- a/apps/server/src/types/errors/oauth/kakao.ts
+++ b/apps/server/src/types/errors/oauth/kakao.ts
@@ -7,3 +7,11 @@ export class KakaoUserInformationError extends APIError {
         Error.captureStackTrace(this, KakaoUserInformationError)
     }
 }
+
+export class KakaoNetworkError extends APIError {
+    constructor(cause: Error | string = null) {
+        super(500, 6051, 'Network error while accessing Kakao API', cause)
+        Object.setPrototypeOf(this, KakaoNetworkError.prototype)
+        Error.captureStackTrace(this, KakaoNetworkError)
+    }
+}

--- a/apps/server/src/types/oauth/oauth.ts
+++ b/apps/server/src/types/oauth/oauth.ts
@@ -1,5 +1,6 @@
 export interface IOAuth {
     getUser(credential: ICredentials): Promise<IUser>
+    unlinkUser(credential: ICredentials): Promise<void>
 }
 
 export interface ICredentials {


### PR DESCRIPTION
<img width="695" alt="image" src="https://github.com/user-attachments/assets/f4d12a75-788d-4c79-97d9-78ae87597e71" />
디비에서 바로 삭제하는 것이 아닌 soft 삭제를 이용하여 isDeleted로 탈퇴회원을 구분하도록 구현하였습니다.
추후 탈퇴 정책을 정의하여 배치를 돌려 주기적으로 삭제하도록 작업할 예정입니다.