### PR TITLE
fix: prevent duplicate API request on back navigation for category page

### DIFF
--- a/apps/web/src/app/(backButton)/events/category/page.tsx
+++ b/apps/web/src/app/(backButton)/events/category/page.tsx
@@ -5,7 +5,7 @@ import { categoryStore } from '@/store'
 
 export default function Page() {
     const { category } = categoryStore()
-    if (!category) {
+    if (category._id === '') {
         return (
             <div className="h-screen flex items-center justify-center px-4">
                 <div className="text-lg text-center">잘못된 접근입니다.</div>


### PR DESCRIPTION
## 버그 발생 현상
현재 카테고리 페이지에서 뒤로 가기를 누를 시 다시 한번 'HTTP GET /v1/events/category/?page=1&limit=10’ 요청이 발생하여 오류가 발생.

## 오류 원인
현재 `(backbutton)/events/category/page.tsx` 에서 뒤로가기 버튼을 누르면 빈 category 정보가 초기화가 됩니다. 그 후에 `router.back()`이 실행됨. 이로 인해 아직 `router.back()`이 실행되기 전에 category 정보가 초기화되고, category._id 값이 변화가 생겼기 때문에 다시 쿼리 요청이 발생하게 됨

## 오류 해결

1. backbutton 로직 순서 반대로 수정 (다른 페이지에서 위와 같은 이슈가 동일하게 발생할 가능성 존재)
2. 해당 페이지에서는 !category를 통해서 category를 빈 것을 확인하고 있었음. cateogry: string → ICategory로 수정된 이후에 수정되지 않아 비어 있다고 판단하지 못함. 

## 결론
2번 방법으로 해결