### PR TITLE
fix: add lru cache required property

### DIFF
--- a/apps/server/src/services/oauth/jwt.ts
+++ b/apps/server/src/services/oauth/jwt.ts
@@ -43,7 +43,10 @@ export function expireJwt(jwt: string) {
     tokenBlackList.set(`ACCESS_${jwt}`, new Date()) // 로그아웃 시점을 기록
 }
 
-const tokenBlackList = new LRUCache({ ttl: REFRESH_TOKEN_EXPIRES_IN * 1000 })
+const tokenBlackList = new LRUCache({
+    maxSize: 1000,
+    ttl: REFRESH_TOKEN_EXPIRES_IN * 1000,
+})
 
 export function isTokenInBlackList(jwt: string): boolean {
     if (!jwt) {

--- a/apps/server/src/services/oauth/jwt.ts
+++ b/apps/server/src/services/oauth/jwt.ts
@@ -40,7 +40,7 @@ export function expireJwt(jwt: string) {
     if (!jwt) {
         throw new InvalidRequestTokenError('jwt must be provided')
     }
-    tokenBlackList.set(`ACCESS_${jwt}`, new Date()) // 로그아웃 시점을 기록
+    tokenBlackList.set(`ACCESS_${jwt}`, new Date(), { size: 1 }) // 로그아웃 시점을 기록
 }
 
 const tokenBlackList = new LRUCache({


### PR DESCRIPTION
lru cache 의 필수 속성을 설정합니다

현재는 임의로 1000으로 설정했습니다.
해당 값은 logout 된 token 을 저장하는 cache 로 1000개 이상 저장이 될 경우 기존 logout 처리한 token 을 다시 사용 가능해집니다
하지만 저희 유저가 1000명 이상이 되기 전까지는 문제가 없을거라 생각됩니다.
추후 실제 유저가 많아지면 해당 값 설정을 변경해야 할수 있습니다