### PR TITLE
fix: category update in event update page

### DIFF
--- a/apps/web/src/app/(backButton)/events/update/category/page.tsx
+++ b/apps/web/src/app/(backButton)/events/update/category/page.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+import { ICategory } from '@fienmee/types'
+import { getEventsCategories } from '@/api/event'
+import { eventStore } from '@/store'
+
+const CategorySelect: React.FC = () => {
+    const { event } = eventStore()
+    const [categories, setCategories] = useState<ICategory[]>(event.category)
+    const router = useRouter()
+
+    useEffect(() => {
+        const fetchCategories = async () => {
+            try {
+                const data = await getEventsCategories()
+                setCategories(data.categories)
+            } catch (error) {
+                console.error('Failed to fetch categories:', error)
+            }
+        }
+        fetchCategories()
+    }, [])
+
+    const handleCategoryClick = (category: ICategory) => {
+        router.push(`/events/update?category=${JSON.stringify(category)}`)
+    }
+
+    return (
+        <div className="p-6">
+            <h1 className="text-xl font-bold mb-4">카테고리 선택</h1>
+            <ul>
+                {categories.map(category => (
+                    <li key={category._id} className="p-2 border-b cursor-pointer hover:bg-gray-100" onClick={() => handleCategoryClick(category)}>
+                        {category.title}
+                    </li>
+                ))}
+            </ul>
+        </div>
+    )
+}
+
+export default CategorySelect

--- a/apps/web/src/app/(backButton)/events/update/page.tsx
+++ b/apps/web/src/app/(backButton)/events/update/page.tsx
@@ -5,12 +5,14 @@ import EventForm from '@/components/events/eventForm'
 import { useEffect, useState } from 'react'
 import { eventStore } from '@/store'
 import { ICategory } from '@fienmee/types'
+import { useSearchParams } from 'next/navigation'
 
 export default function EventUpdate() {
+    const searchParams = useSearchParams()
+    const category = searchParams.get('category')
     const { event, setEvent } = eventStore()
     const [selectedCategories, setSelectedCategories] = useState<Set<ICategory>>(new Set(event.category))
     const [isAllDay, setIsAllDay] = useState(false)
-    const category = event.category
     const handleAddPhoto = (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = Array.from(e.target.files || [])
         const newPhotos = files.map(file => URL.createObjectURL(file))
@@ -20,7 +22,8 @@ export default function EventUpdate() {
 
     useEffect(() => {
         if (category) {
-            setSelectedCategories(prev => new Set([...prev, ...category]))
+            const parsedCategory = JSON.parse(category)
+            setSelectedCategories(new Set([parsedCategory]))
         }
     }, [category])
 

--- a/apps/web/src/app/(backButton)/events/update/page.tsx
+++ b/apps/web/src/app/(backButton)/events/update/page.tsx
@@ -2,12 +2,20 @@
 
 import PhotoUploader from '@/components/events/photoUploader'
 import EventForm from '@/components/events/eventForm'
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { eventStore } from '@/store'
 import { ICategory } from '@fienmee/types'
 import { useSearchParams } from 'next/navigation'
 
 export default function EventUpdate() {
+    return (
+        <Suspense fallback={<div>Loading...</div>}>
+            <UpdatePageContent />
+        </Suspense>
+    )
+}
+
+function UpdatePageContent() {
     const searchParams = useSearchParams()
     const category = searchParams.get('category')
     const { event, setEvent } = eventStore()

--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -26,6 +26,10 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
         router.push('/events/register/category')
     }
 
+    const handleUpdateCategorySelect = () => {
+        router.push('/events/update/category')
+    }
+
     const [position, setPosition] = useState(
         initEvent ? { lat: initEvent.location.coordinates[1], lng: initEvent.location.coordinates[0] } : { lat: 33.450701, lng: 126.570667 },
     )
@@ -125,7 +129,7 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
                         </span>
                     ))}
                 </div>
-                <button type="button" onClick={handleCategorySelect} className="text-blue-500 ml-auto">
+                <button type="button" onClick={initEvent ? handleUpdateCategorySelect : handleCategorySelect} className="text-blue-500 ml-auto">
                     <ArrowIcon width={24} height={24} />
                 </button>
             </div>
@@ -158,7 +162,7 @@ const EventForm: React.FC<EventFormProps> = ({ isAllDay, toggleAllDay, selectedC
                 name="description"
                 onChange={handleChange}
             />
-            <SubmitButton label="등록하기" />
+            <SubmitButton label={initEvent ? '수정하기' : '등록하기'} />
         </form>
     )
 }


### PR DESCRIPTION
이벤트 수정 페이지에서 카테고리가 제대로 수정되지 않는 현상을 해결하였습니다.

원인
- 카테고리 수정 시 등록 페이지의 카테고리 페이지로 이동 되어 수정된 내용을 제대로 불러오지 못하였음

개선
- 이벤트 수정 내부에 카테고리 페이지를 만들어서 수정의 경우 해당 페이지로 이동하도록 변경