### PR TITLE
feat: add event's likes status change API

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -72,6 +72,17 @@ router.get('/:id', verifyToken, async (req: Request, res: Response) => {
     res.status(200).json({ ...event, isAuthor: event.authorId.equals(req.user._id) })
 })
 
+router.post('/:id/likes', verifyToken, async (req: Request, res: Response) => {
+    const event = await EventsModel.findById(req.params.id)
+
+    const prevLiked = event.likes.includes(req.user._id)
+    const update = prevLiked ? { $pull: { likes: req.user._id } } : { $push: { likes: req.user._id } }
+
+    await EventsModel.updateOne({ _id: req.params.id }, update)
+
+    res.sendStatus(204)
+})
+
 router.get('/category/:category', verifyToken, async (req: Request, res: Response) => {
     const options = { sort: { startDate: 1, endDate: 1, createdAt: -1 }, page: Number(req.query.page) || 1, limit: Number(req.query.limit) || 10 }
     const category = await CategoryModel.getCategoryById(req.params.category)
@@ -83,7 +94,11 @@ router.get('/category/:category', verifyToken, async (req: Request, res: Respons
         // TODO: add get hottest events
         result = await EventsModel.findByCategory(category._id, options)
     }
-    const events = result.docs.map(event => ({ ...event.toJSON(), isAuthor: event.get('authorId')?.equals(req.user._id) }))
+    const events = result.docs.map(event => ({
+        ...event.toJSON(),
+        isAuthor: event.get('authorId')?.equals(req.user._id),
+        isLiked: event.get('likes')?.includes(req.user._id),
+    }))
 
     res.status(200).json({
         events: events,


### PR DESCRIPTION
행사 좋아요 표시를 위한 API를 추가하였습니다.
카테고리에서 행사를 조회할 때 유저의 좋아요 여부를 함께 반환하는 부분을 추가했습니다.