### PR TITLE
feat: add likes function in event detail page

### DIFF
--- a/apps/web/src/api/event.ts
+++ b/apps/web/src/api/event.ts
@@ -57,3 +57,13 @@ export async function updateEvent(request: IPutEventRequest): Promise<void> {
     }
     return
 }
+
+export async function updateEventLikes(id: string) {
+    const res = await fetch(`${SERVER_URL}/v1/events/${id}/likes`, {
+        method: 'POST',
+    })
+    if (!res.ok) {
+        throw new Error(`code: ${res.status}\ndescription: ${res.statusText}`)
+    }
+    return
+}

--- a/apps/web/src/components/events/eventDetail.tsx
+++ b/apps/web/src/components/events/eventDetail.tsx
@@ -1,10 +1,11 @@
 import { IEvent } from '@fienmee/types'
 import dayjs from 'dayjs'
 import 'dayjs/locale/ko'
-import { CommentIcon, ShareIcon, UnlikeIcon } from '@/components/icon'
+import { CommentIcon, ShareIcon } from '@/components/icon'
 import { EventMap } from '@/components/events/eventMap'
 import EventOption from '@/components/events/eventOption'
 import EventPhoto from '@/components/events/eventPhoto'
+import EventLikes from '@/components/events/eventLikes'
 
 interface Props {
     event: IEvent
@@ -58,11 +59,7 @@ export default function EventDetail({ event }: Props) {
                 </div>
             </div>
             <div className="flex justify-between p-4 mt-4 pt-4 border-t border-gray-200">
-                {/* TODO: add like function */}
-                <button className="flex items-center space-x-3">
-                    <UnlikeIcon width="1.25rem" height="1.25rem" />
-                    <span className="text-sm">{event.likeCount}</span>
-                </button>
+                <EventLikes />
                 <div className="flex items-center space-x-3">
                     <CommentIcon width="1.25rem" height="1.25rem" />
                     <div className="text-sm">{event.commentCount}</div>

--- a/apps/web/src/components/events/eventLikes.tsx
+++ b/apps/web/src/components/events/eventLikes.tsx
@@ -1,0 +1,37 @@
+import { eventStore } from '@/store'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { updateEventLikes } from '@/api/event'
+import { LikeIcon, UnlikeIcon } from '@/components/icon'
+
+export default function EventLikes() {
+    const { event, setEvent } = eventStore()
+    const queryClient = useQueryClient()
+
+    const mutation = useMutation({
+        mutationFn: (eventId: string) => {
+            return updateEventLikes(eventId)
+        },
+        onSuccess: async () => {
+            setEvent({
+                ...event,
+                likeCount: event.isLiked ? event.likeCount - 1 : event.likeCount + 1,
+                isLiked: !event.isLiked,
+            })
+            await queryClient.invalidateQueries({ queryKey: ['events'] })
+        },
+    })
+
+    const handleClick = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+        e.preventDefault()
+        mutation.mutate(event._id)
+    }
+
+    return (
+        <>
+            <button className="flex items-center space-x-3" onClick={handleClick}>
+                {event.isLiked ? <LikeIcon width="1.5rem" height="1.25rem" /> : <UnlikeIcon width="1.5rem" height="1.25rem" />}
+                <span className="text-sm">{event.likeCount}</span>
+            </button>
+        </>
+    )
+}

--- a/apps/web/src/store/event.ts
+++ b/apps/web/src/store/event.ts
@@ -27,6 +27,7 @@ const initEvent: IEvent = {
     createdAt: new Date(),
     isAuthor: false,
     isAllDay: false,
+    isLiked: false,
 }
 
 export const eventStore = create<eventState>(set => ({

--- a/packages/types/api/events.ts
+++ b/packages/types/api/events.ts
@@ -20,6 +20,7 @@ export interface IEvent {
     createdAt: Date
     isAuthor: boolean
     isAllDay: boolean
+    isLiked: boolean
 }
 
 export interface IGetEventsByCategoryResponse {


### PR DESCRIPTION
FE에 행사 좋아요 API 연동 작업을 진행하였습니다.
행사 조회 페이지에서 좋아요 표시가 가능합니다.

<img width="180" alt="image" src="https://github.com/user-attachments/assets/10c6b86f-5e2d-4726-b7ab-9e0c3491288e" />
