### PR TITLE
chore: deploy docker image

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,51 @@
+name: fienmee CD
+
+on:
+    push:
+        branches:
+            - main
+            - develop
+
+env:
+    BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+    build-and-push-image:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - dockerfile: ./Dockerfile_SERVER
+                      image: ghcr.io/beyond-imagination/fienmee-server
+                    - dockerfile: ./Dockerfile_WEB
+                      image: ghcr.io/beyond-imagination/fienmee-web
+        permissions:
+            contents: read
+            packages: write
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Log in to the Container registry
+              uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Extract metadata (tags, labels) for Docker
+              id: meta
+              uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+              with:
+                  images: ${{ matrix.image }}-${{ env.BRANCH_NAME }}
+
+            - name: Build and push Docker image
+              uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+              with:
+                  context: .
+                  file: ${{ matrix.dockerfile }}
+                  push: true
+                  tags: ${{ steps.meta.outputs.tags }}
+                  labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
main 브랜치와 develop 브랜치에 코드 push 시 docker image 를 ghcr에 배포합니다