### PR TITLE
feat: 에러 처리 페이지 생성

### DIFF
--- a/apps/web/src/app/(backButton)/events/error/_error.tsx
+++ b/apps/web/src/app/(backButton)/events/error/_error.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { ErrorPage } from '@/components/errorPage'
+
+export default function NotFound() {
+    return <ErrorPage />
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React from 'react'
 import { ErrorPage } from '@/components/errorPage'
 

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,15 +1,18 @@
 'use client'
 
-import React from 'react'
+import React, { useEffect } from 'react'
 import { ErrorPage } from '@/components/errorPage'
 
-export default function GlobalError({ error }: { error: Error }) {
-    console.error(error)
+export default function GlobalError({ error, reset }: { error: Error; reset: () => void }) {
+    useEffect(() => {
+        console.error(error)
+    }, [error])
 
     return (
         <html>
             <body>
                 <ErrorPage />
+                <button onClick={() => reset()}>다시 시도</button>
             </body>
         </html>
     )

--- a/apps/web/src/components/errorPage.tsx
+++ b/apps/web/src/components/errorPage.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import React from 'react'
+
+export function ErrorPage() {
+    return (
+        <div style={{ textAlign: 'center', marginTop: '5rem' }}>
+            <h1>문제가 발생했습니다.</h1>
+            <p>이용에 불편을 드려 죄송합니다.</p>
+        </div>
+    )
+}


### PR DESCRIPTION
코멘트 반영했습니다
- [x] use client 추가
- [x] reset 함수를 prop로 받아 에러 해제하는 코드 추가


추가수정사항 있으면 말씀해주세요
+ `error: Error & { digest?: string }` 에서 `& { digest?: string }` <- 이부분 선택 옵션인 것 같아서 안넣었는데 혹시 필수로 넣어야 하거나 권장사항이면 말씀해주세요 반영하겠습니다.