### PR TITLE
style: update Schedule page to match UI Design

### DIFF
--- a/apps/web/src/app/(navigation)/schedules/page.tsx
+++ b/apps/web/src/app/(navigation)/schedules/page.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react'
 export default function Schedules() {
     const [selectedDay, setSelectedDay] = useState<Date>(new Date())
     return (
-        <div className="flex flex-col items-center">
+        <div className="flex flex-col items-center gap-2 bg-[#F6F5F5]">
             <ScheduleCalendar onChange={newDate => setSelectedDay(newDate as Date)} />
             <ScheduleList date={selectedDay as Date} />
         </div>

--- a/apps/web/src/components/icon/schedule.tsx
+++ b/apps/web/src/components/icon/schedule.tsx
@@ -1,0 +1,17 @@
+import { IconProps } from '@/components/icon/icon'
+
+export function NextLabelIcon({ width, height }: IconProps) {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox="0 0 8 12" fill="none">
+            <path d="M4.6 6L0 1.4L1.4 0L7.4 6L1.4 12L0 10.6L4.6 6Z" fill="#49454F" />
+        </svg>
+    )
+}
+
+export function PrevLabelIcon({ width, height }: IconProps) {
+    return (
+        <svg xmlns="http://www.w3.org/2000/svg" width={width} height={height} viewBox="0 0 8 12" fill="none">
+            <path d="M6 12L0 6L6 0L7.4 1.4L2.8 6L7.4 10.6L6 12Z" fill="#49454F" />
+        </svg>
+    )
+}

--- a/apps/web/src/components/schedules/calendar.css
+++ b/apps/web/src/components/schedules/calendar.css
@@ -8,6 +8,15 @@
     line-height: 1.125em;
 }
 
+.react-calendar__navigation {
+    display: grid !important;
+    grid-template-columns: 1fr auto auto;
+    grid-template-rows: 1fr;
+    align-items: center;
+    justify-items: start;
+    padding: 0.25rem 0.75rem 0.25rem 1rem;
+}
+
 .react-calendar__navigation button {
     min-width: 44px;
     background: none;
@@ -22,6 +31,23 @@
     background-color: #f0f0f0;
 }
 
+.react-calendar__navigation__arrow {
+    display: flex;
+    justify-content: center;
+}
+
+.react-calendar__navigation__label {
+    order: 1;
+}
+
+.react-calendar__navigation__prev-button {
+    order: 2;
+}
+
+.react-calendar__navigation__next-button {
+    order: 3;
+}
+
 .react-calendar__month-view__weekdays {
     text-align: center;
     text-transform: uppercase;
@@ -29,8 +55,14 @@
     font-size: 0.75em;
 }
 
+.react-calendar__month-view__weekdays__weekday abbr {
+    font-size: 1rem;
+    font-weight: normal;
+    text-decoration: none;
+}
+
 .react-calendar__month-view__weekdays__weekday {
-    padding: 0.5em;
+    padding: 1.5rem 0.5rem 0.5rem 0.5rem;
 }
 
 .react-calendar__month-view__days__day--weekend {

--- a/apps/web/src/components/schedules/scheduleCalendar.tsx
+++ b/apps/web/src/components/schedules/scheduleCalendar.tsx
@@ -1,6 +1,7 @@
 import Calendar from 'react-calendar'
 import './calendar.css'
 import { CalendarDateRange } from '@fienmee/types'
+import { NextLabelIcon, PrevLabelIcon } from '@/components/icon/schedule'
 
 interface ScheduleCalendarProps {
     onChange: (value: Date) => void
@@ -17,7 +18,7 @@ export default function ScheduleCalendar({ onChange }: ScheduleCalendarProps) {
     }
 
     return (
-        <div className="bg-white shadow-lg rounded-lg p-4">
+        <div className="bg-white rounded-lg p-4 border-b border-b-[#E4E4E4]">
             <Calendar
                 onChange={handleChange}
                 calendarType="gregory"
@@ -33,7 +34,9 @@ export default function ScheduleCalendar({ onChange }: ScheduleCalendarProps) {
                     const weekdays = ['S', 'M', 'T', 'W', 'T', 'F', 'S']
                     return weekdays[date.getDay()]
                 }}
+                prevLabel={PrevLabelIcon({ width: '0.5rem', height: '0.75rem' })}
                 prev2Label={null}
+                nextLabel={NextLabelIcon({ width: '0.5rem', height: '0.75rem' })}
                 next2Label={null}
                 showNeighboringMonth={false}
                 tileClassName={({ date, view }) => {

--- a/apps/web/src/components/schedules/sheduleList.tsx
+++ b/apps/web/src/components/schedules/sheduleList.tsx
@@ -16,13 +16,6 @@ interface IScheduleSummary {
 }
 
 export default function ScheduleList({ date }: Prop) {
-    const formatDate = (date: Date) => {
-        const year = date.getFullYear()
-        const month = String(date.getMonth() + 1).padStart(2, '0')
-        const day = String(date.getDate()).padStart(2, '0')
-        return `${year}-${month}-${day}`
-    }
-
     const { data, isLoading, isError, fetchNextPage } = useSchedulesByDate({ date: date, startPage: 1, limit: 5 })
     const { ref, inView } = useInView()
 
@@ -34,7 +27,7 @@ export default function ScheduleList({ date }: Prop) {
 
     if (isError) {
         return (
-            <div className="h-screen flex items-center justify-center px-4">
+            <div className="flex w-full items-center justify-center px-4 pt-4 bg-white border-t border-t-[#E4E4E4]">
                 <div className="text-lg text-center">
                     <h1>일정을 불러오는 것을 실패하였습니다.</h1>
                     <p>다시 시도해주세요</p>
@@ -52,8 +45,8 @@ export default function ScheduleList({ date }: Prop) {
         })
     }
     return (
-        <div>
-            <div className="ml-5 mt-6 mb-3 text-xl font-bold text-left">{formatDate(date)} 일정</div>
+        <div className="bg-white w-full border-t border-t-[#E4E4E4]">
+            <div className="ml-5 mt-6 mb-3 text-xl font-bold text-left">{String(date.getDate()).padStart(2, '0')}일 일정</div>
             <div>{schedules && schedules.map((schedule: IScheduleSummary) => <ScheduleItem key={schedule.id} {...schedule} />)}</div>
             <div ref={ref}></div>
         </div>


### PR DESCRIPTION
기존 UI 설계와 동일하게 schedule page 의 UI를 소폭 수정합니다.

날짜 위 active icon은 추후 schedule 목록 api를 가져오는 경우 반영될 예정입니다. (현재 조건문이 항상 true)

![image](https://github.com/user-attachments/assets/081ab698-2a61-4d69-94d8-414e2d1cb705)