### PR TITLE
feat: add schedule detail modal

### DIFF
--- a/apps/server/src/controllers/v1/schedules.ts
+++ b/apps/server/src/controllers/v1/schedules.ts
@@ -11,7 +11,7 @@ router.post('/', middlewares.schedules.addScheduleMiddleware, async (req: Reques
     const schedule = await ScheduleModel.create({
         name: name,
         eventId: eventId,
-        authorId: req.user._id.toString(),
+        authorId: req.user._id,
         startDate: startDate,
         endDate: endDate,
         address: address,

--- a/apps/server/src/middlewares/schedules.ts
+++ b/apps/server/src/middlewares/schedules.ts
@@ -8,7 +8,8 @@ export const verifyAuthorMiddleware = async (req: Request, res: Response, next: 
     if (!authorId) {
         throw new UnauthorizedSchedule(new Error('not found target schedule'))
     }
-    if (req.user?._id !== authorId) {
+
+    if (!req.user?._id.equals(authorId)) {
         throw new UnauthorizedSchedule()
     }
     next()

--- a/apps/web/src/api/event.ts
+++ b/apps/web/src/api/event.ts
@@ -1,4 +1,5 @@
 import {
+    IEvent,
     IGetEventCategoriesResponse,
     IGetEventsByCategoryResponse,
     IPostEventCommentRequest,
@@ -83,4 +84,14 @@ export async function registerEventComments(request: IPostEventCommentRequest) {
         throw await res.json()
     }
     return
+}
+
+export async function getEventDetail(eventId: string): Promise<IEvent> {
+    const res = await fetch(`${SERVER_URL}/v1/events/${eventId}`, {
+        method: 'GET',
+    })
+    if (!res.ok) {
+        throw await res.json()
+    }
+    return res.json()
 }

--- a/apps/web/src/api/schedules.ts
+++ b/apps/web/src/api/schedules.ts
@@ -1,5 +1,5 @@
 import { SERVER_URL } from '@/config'
-import { IGetScheduleListResponse, IMakeNewScheduleRequest, IMakeNewScheduleResponse } from '@fienmee/types'
+import { IGetScheduleListResponse, IMakeNewScheduleRequest, IMakeNewScheduleResponse, IScheduleItem } from '@fienmee/types'
 
 export async function getSchedulesByDate(date: Date, page: number, limit: number): Promise<IGetScheduleListResponse> {
     const from = `${date.getFullYear()}.${date.getMonth()}.${date.getDate()}`
@@ -18,6 +18,16 @@ export async function registerSchedule(schedule: IMakeNewScheduleRequest): Promi
     const res = await fetch(`${SERVER_URL}/v1/schedules`, {
         method: 'POST',
         body: JSON.stringify(schedule),
+    })
+    if (!res.ok) {
+        throw await res.json()
+    }
+    return res.json()
+}
+
+export async function getScheduleDetail(scheduleId: string): Promise<IScheduleItem> {
+    const res = await fetch(`${SERVER_URL}/v1/schedules/${scheduleId}`, {
+        method: 'GET',
     })
     if (!res.ok) {
         throw await res.json()

--- a/apps/web/src/components/schedules/scheduleDetail.tsx
+++ b/apps/web/src/components/schedules/scheduleDetail.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react'
+import { IScheduleItem } from '@fienmee/types'
+import { EventMap } from '@/components/events/eventMap'
+import Link from 'next/link'
+import { eventStore } from '@/store'
+import { getEventDetail } from '@/api/event'
+import { getScheduleDetail } from '@/api/schedules'
+
+interface ScheduleDetailModalProps {
+    isOpen: boolean
+    onClose: () => void
+    scheduleId: string
+}
+
+export default function ScheduleDetailModal({ isOpen, onClose, scheduleId }: ScheduleDetailModalProps) {
+    const [schedule, setSchedule] = useState<IScheduleItem | null>(null)
+    const { setEvent } = eventStore()
+
+    useEffect(() => {
+        const fetchSchedule = async () => {
+            if (scheduleId && isOpen) {
+                const data = await getScheduleDetail(scheduleId)
+                setSchedule(data)
+            }
+        }
+
+        fetchSchedule()
+    }, [scheduleId, isOpen])
+
+    const onClick = async (eventId: string) => {
+        const event = await getEventDetail(eventId)
+        setEvent(event)
+    }
+
+    const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (e.target === e.currentTarget) {
+            onClose()
+        }
+    }
+
+    if (!isOpen || !schedule) return null
+
+    const formatTime = (date: Date) => {
+        return `${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')} ${date.getHours() >= 12 ? 'PM' : 'AM'}`
+    }
+    const timeRange = schedule.isAllDay ? '하루 종일' : `${formatTime(schedule.startDate)} - ${formatTime(schedule.endDate)}`
+
+    return (
+        <div className="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-end" onClick={handleBackdropClick}>
+            <div className="bg-white w-full h-[70%] rounded-t-2xl shadow-lg overflow-y-auto flex flex-col">
+                <div className="p-10 flex-1 overflow-auto">
+                    <div className="text-lg font-semibold mb-2">{schedule.name}</div>
+                    <div className="text-sm text-gray-400 mb-4">{timeRange}</div>
+                    <hr className="border-t border-gray-300 mb-4" />
+
+                    <div className="mb-4 py-2">
+                        <div className="flex justify-between items-center mb-1 w-full">
+                            <div className="text-m text-left">장소</div>
+                            <div className="text-base font-semibold text-right">{schedule.address}</div>
+                        </div>
+
+                        <div className="mt-2 border border-gray-200 rounded-lg h-32 overflow-hidden">
+                            <EventMap lng={schedule.location.coordinates[0]} lat={schedule.location.coordinates[1]} />
+                        </div>
+                    </div>
+
+                    <hr className="border-t border-gray-300 mb-4" />
+                    <div className="mb-4">
+                        <div className="text-m">메모</div>
+                        <div className="text-sm text-gray-500 whitespace-pre-line">{schedule.description || '작성된 메모가 없습니다.'}</div>
+                    </div>
+                    <hr className="border-t border-gray-300 mb-4" />
+                </div>
+
+                <div className="px-14 py-4">
+                    <Link
+                        className="block text-center bg-[#FF9575] text-white py-3 rounded-lg w-full font-semibold"
+                        href={`/events/detail`}
+                        onClick={() => onClick(schedule.eventId)}
+                    >
+                        행사 더 자세히 보러 가기
+                    </Link>
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/apps/web/src/components/schedules/scheduleDetail.tsx
+++ b/apps/web/src/components/schedules/scheduleDetail.tsx
@@ -45,6 +45,7 @@ export default function ScheduleDetailModal({ isOpen, onClose, scheduleId }: Sch
     }
     const timeRange = schedule.isAllDay ? '하루 종일' : `${formatTime(schedule.startDate)} - ${formatTime(schedule.endDate)}`
 
+    // TODO: 좌우 슬라이드를 통한 일정 상세 조회
     return (
         <div className="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-end" onClick={handleBackdropClick}>
             <div className="bg-white w-full h-[70%] rounded-t-2xl shadow-lg overflow-y-auto flex flex-col">

--- a/apps/web/src/components/schedules/scheduleItem.tsx
+++ b/apps/web/src/components/schedules/scheduleItem.tsx
@@ -1,12 +1,12 @@
 interface ScheduleProp {
     time: string
     title: string
+    onClick?: () => void
 }
 
-export default function ScheduleItem({ time, title }: ScheduleProp) {
+export default function ScheduleItem({ time, title, onClick }: ScheduleProp) {
     return (
-        // todo: 클릭 시 일정 조회 상세 페이지로 이동
-        <div className="grid grid-cols-5 divide-x-1">
+        <div className="grid grid-cols-5 divide-x-1" onClick={onClick}>
             <div className="col-span-1 pr-4 m-4 border-r-2 border-r-gray-500">{time}</div>
             <div className="col-span-4 m-4">{title}</div>
         </div>

--- a/apps/web/src/components/schedules/sheduleList.tsx
+++ b/apps/web/src/components/schedules/sheduleList.tsx
@@ -2,8 +2,9 @@ import ScheduleItem from '@/components/schedules/scheduleItem'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { getSchedulesByDate } from '@/api/schedules'
 import { useInView } from 'react-intersection-observer'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { IScheduleItem } from '@fienmee/types'
+import ScheduleDetailModal from '@/components/schedules/scheduleDetail'
 
 interface Prop {
     date: Date
@@ -18,12 +19,23 @@ interface IScheduleSummary {
 export default function ScheduleList({ date }: Prop) {
     const { data, isLoading, isError, fetchNextPage } = useSchedulesByDate({ date: date, startPage: 1, limit: 5 })
     const { ref, inView } = useInView()
+    const [isModalOpen, setIsModalOpen] = useState(false)
+    const [selectedId, setSelectedId] = useState<string>('')
 
     useEffect(() => {
         if (inView) {
             fetchNextPage()
         }
     }, [inView, fetchNextPage])
+
+    const handleClick = (scheduleId: string) => {
+        setIsModalOpen(true)
+        setSelectedId(scheduleId)
+    }
+
+    const handleClose = () => {
+        setIsModalOpen(false)
+    }
 
     if (isError) {
         return (
@@ -47,8 +59,15 @@ export default function ScheduleList({ date }: Prop) {
     return (
         <div className="bg-white w-full border-t border-t-[#E4E4E4]">
             <div className="ml-5 mt-6 mb-3 text-xl font-bold text-left">{String(date.getDate()).padStart(2, '0')}일 일정</div>
-            <div>{schedules && schedules.map((schedule: IScheduleSummary) => <ScheduleItem key={schedule.id} {...schedule} />)}</div>
+            <div>
+                {schedules &&
+                    schedules.map((schedule: IScheduleSummary) => (
+                        <ScheduleItem key={schedule.id} {...schedule} onClick={() => handleClick(schedule.id)} />
+                    ))}
+            </div>
             <div ref={ref}></div>
+
+            {selectedId && <ScheduleDetailModal isOpen={isModalOpen} onClose={handleClose} scheduleId={selectedId} />}
         </div>
     )
 }


### PR DESCRIPTION
FE에 일정 상세 조회 기능을 추가하였습니다.
- 기존 코드 변경 사항
    - 미들웨어에서 authorId가 일치하는지 확인하는 작업에서 equals를 사용하도록 변경
- 추가된 내용
    - 이벤트 상세 조회, 일정 상세 조회 API 추가(FE)
    - 일정 내용을 보여줄 수 있는 모달 추가
    - 모달에서 행사 더 자세히 보러가기 버튼 클릭 시 해당 이벤트 페이지로 이동하도록 연결
 
피그마 상으론 좌우 스크롤을 통해 해당 날짜에 다른 일정을 보여줄 수 있는데, 이 부분까지 구현하려면 시간이 더 걸릴 것 같아 우선 TODO로 남기고 조회만 되도록 적용하였습니다.


<img width="188" alt="image" src="https://github.com/user-attachments/assets/6375b8bc-114b-4bf6-97fd-e17ef75f6a5a" />
