### PR TITLE
fix: event register button name

### DIFF
--- a/apps/web/src/app/(backButton)/events/register/category/page.tsx
+++ b/apps/web/src/app/(backButton)/events/register/category/page.tsx
@@ -33,7 +33,7 @@ const CategorySelect: React.FC = () => {
                     <li
                         key={category._id}
                         className="p-2 border-b cursor-pointer hover:bg-gray-100"
-                        onClick={() => router.push(`/events/register/category/${category._id}`)}
+                        onClick={() => router.push(`/events/register?category=${JSON.stringify(category)}`)}
                     >
                         {category.title}
                     </li>

--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -112,7 +112,7 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, photos, initE
                         </span>
                     ))}
                 </div>
-                <button type="button" onClick={initEvent ? handleUpdateCategorySelect : handleCategorySelect} className="text-blue-500 ml-auto">
+                <button type="button" onClick={isRegister ? handleCategorySelect : handleUpdateCategorySelect} className="text-blue-500 ml-auto">
                     <ArrowIcon width="1.5rem" height="1.5rem" />
                 </button>
             </div>


### PR DESCRIPTION
행사 등록 페이지에서 카테고리 수정 후 버튼이 등록하기에서 수정하기로 바뀌는 현상을 수정하였습니다.

원인
- initEvent을 사용해서 어떤 카테고리 페이지로 이동할지 결정해서 등록하기도 수정하기의 카테고리 선택 페이지로 이동
- 등록하기의 카테고리 선택 페이지에서 선택 후 돌아오는 경로가 잘못되어 등록하기 페이지로 돌아오지 못함

해결 방안
- initEvent가 아닌 isRegister를 사용해서 어떤 카테고리 페이지로 이동할지 결정
- 등록하기의 카테고리 선택 페이지에서 이동하는 경로 수정