### PR TITLE
style: remove scroll from home screen sections and display 3 events per section

### DIFF
--- a/apps/web/src/app/(navigation)/(home)/page.tsx
+++ b/apps/web/src/app/(navigation)/(home)/page.tsx
@@ -33,7 +33,7 @@ function PageComponent() {
             <div className="px-8 mb-8">
                 <SearchBar />
             </div>
-            <div className="grid gap-10 w-full px-1 pb-10">
+            <div className="grid gap-10 w-full px-1">
                 {/*TODO: change event category*/}
                 <PreviewEventLst title={`${today.getDate()}일 일정`} category={data.categories[0]._id} />
                 <div className="bg-[#F6F5F5] shadow-inner shadow-[#E4E4E4] w-full h-2" />

--- a/apps/web/src/components/events/event.tsx
+++ b/apps/web/src/components/events/event.tsx
@@ -41,7 +41,7 @@ export default function Event({ event }: Props) {
         <Link
             href={`/events/detail`}
             onClick={onClick}
-            className="flex hover:bg-gray-100 transition duration-300 justify-between items-start gap-4 px-4 mb-12"
+            className="flex hover:bg-gray-100 transition duration-300 justify-between items-start gap-4 px-4"
         >
             <div className="flex flex-col w-2/3 ps-2 pt-2 gap-2">
                 <div className="text-xl font-semibold">{event.name}</div>

--- a/apps/web/src/components/events/eventList.tsx
+++ b/apps/web/src/components/events/eventList.tsx
@@ -54,7 +54,7 @@ export function EventList({ category }: { category: string }) {
 
     return (
         <div className="h-full w-full">
-            <div className="h-full w-full px-2 mt-4">
+            <div className="flex flex-col h-full w-full px-2 mt-4 gap-6">
                 {data && data.pages.map(events => events.events.map(event => <Event event={event} key={event._id} />))}
             </div>
             {isFetchingNextPage ? <Event event={undefined} /> : <div ref={ref} />}

--- a/apps/web/src/components/events/previewEventList.tsx
+++ b/apps/web/src/components/events/previewEventList.tsx
@@ -1,4 +1,9 @@
-import { EventList } from '@/components/events/eventList'
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { IGetEventsByCategoryResponse } from '@fienmee/types'
+import { getEventsByCategory } from '@/api/event'
+import Event from '@/components/events/event'
 
 interface Props {
     title: string
@@ -6,12 +11,41 @@ interface Props {
 }
 
 export default function PreviewEventLst({ title, category }: Props) {
+    const { data, isLoading, isError } = useQuery<IGetEventsByCategoryResponse>({
+        queryKey: ['events', category],
+        queryFn: () => getEventsByCategory(category, 1, 3),
+    })
+
+    if (isLoading) {
+        return (
+            <div className="h-full w-full">
+                <div className="h-full w-full px-2 mt-4">
+                    {Array.from({ length: 3 }, (_, index) => (
+                        <Event event={undefined} key={index} />
+                    ))}
+                </div>
+            </div>
+        )
+    }
+
+    if (isError) {
+        return (
+            <div className="h-screen flex items-center justify-center px-4">
+                <div className="text-lg text-center">
+                    행사를 불러오는 데 실패하였습니다.
+                    <br />
+                    다시 시도해 주시길 바랍니다.
+                </div>
+            </div>
+        )
+    }
+
     return (
         <div className="flex flex-col items-start gap-4">
             <span className="inline-block text-2xl text-[#FF9575] font-bold border-b-[1.5px] border-b-[#FF9575] ms-4">{title}</span>
-            <div className="w-full max-h-[55vh] overflow-y-auto">
+            <div className="flex flex-col w-full gap-8">
                 {/*TODO: change event list for preview list*/}
-                <EventList category={category} />
+                {data && data.events.map(event => <Event event={event} key={event._id} />)}
             </div>
         </div>
     )


### PR DESCRIPTION
홈 화면의 3개 영역에서 스크롤을 제거하고, 3개의 행사만 보여줄 수 있도록 수정합니다. 

여전히 제목과 다른 내용을 가져오고 있기 때문에 추후 BE api 개발 및 쿼리 요청이 필요합니다. 