### PR TITLE
feat: daily schedule count api

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -17,6 +17,7 @@
         "compression": "^1.7.5",
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
+        "date-fns": "^4.1.0",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
         "express-asyncify": "^2.1.2",

--- a/apps/server/src/controllers/v1/schedules.ts
+++ b/apps/server/src/controllers/v1/schedules.ts
@@ -1,7 +1,9 @@
 import asyncify from 'express-asyncify'
 import express, { Request, Response, Router } from 'express'
+
 import { ScheduleModel } from '@/models'
 import middlewares from '@/middlewares'
+import { getUserDailyScheduleCount } from '@/services/schedule'
 
 const router: Router = asyncify(express.Router())
 router.use(middlewares.auth.verifyToken)
@@ -39,6 +41,14 @@ router.get('/', async (req: Request, res: Response) => {
     const schedules = await ScheduleModel.findByUserId(userId, filterOption, options)
 
     res.status(200).json(schedules)
+})
+
+router.get('/dailyCount', middlewares.schedules.verifyAuthorMiddleware, async (req: Request, res: Response) => {
+    const from = new Date(req.query.from as string) || new Date(0)
+    const to = new Date(req.query.to as string) || new Date()
+
+    const dailyScheduleCount = await getUserDailyScheduleCount(req.user, from, to)
+    res.status(200).json(dailyScheduleCount)
 })
 
 router.get('/:id', middlewares.schedules.verifyAuthorMiddleware, async (req: Request, res: Response) => {

--- a/apps/server/src/models/schedule.ts
+++ b/apps/server/src/models/schedule.ts
@@ -3,6 +3,7 @@ import mongoosePaginate from 'mongoose-paginate-v2'
 import mongoose from 'mongoose'
 
 import { User, Events } from '@/models'
+import { IDailyScheduleCount } from '@fienmee/types/api'
 
 @plugin(mongoosePaginate)
 export class Schedule extends defaultClasses.TimeStamps {
@@ -56,6 +57,50 @@ export class Schedule extends defaultClasses.TimeStamps {
         },
     ) {
         return await this.paginate({ authorId: userId, startDate: { $lte: filterOption.to }, endDate: { $gte: filterOption.from } }, options)
+    }
+
+    public static async findDailyCountByUserId(
+        this: ReturnModelType<typeof Schedule>,
+        user: User,
+        from: Date,
+        to: Date,
+    ): Promise<IDailyScheduleCount[]> {
+        return this.aggregate([
+            {
+                $match: {
+                    authorId: user._id,
+                    startDate: { $gte: from, $lt: to },
+                },
+            },
+            {
+                $group: {
+                    _id: {
+                        year: { $year: '$startDate' },
+                        month: { $month: '$startDate' },
+                        day: { $dayOfMonth: '$startDate' },
+                    },
+                    count: { $sum: 1 },
+                },
+            },
+            {
+                $project: {
+                    _id: 0,
+                    date: {
+                        $dateToString: {
+                            format: '%Y-%m-%d',
+                            date: {
+                                $dateFromParts: {
+                                    year: '$_id.year',
+                                    month: '$_id.month',
+                                    day: '$_id.day',
+                                },
+                            },
+                        },
+                    },
+                    count: 1,
+                },
+            },
+        ])
     }
 }
 

--- a/apps/server/src/services/schedule.ts
+++ b/apps/server/src/services/schedule.ts
@@ -1,0 +1,20 @@
+import { eachDayOfInterval, format } from 'date-fns'
+
+import { ScheduleModel, User } from '@/models'
+import { IDailyCountMap } from '@fienmee/types/api'
+
+export async function getUserDailyScheduleCount(user: User, from: Date, to: Date): Promise<IDailyCountMap> {
+    const dates = eachDayOfInterval({ start: from, end: to }).map(d => format(d, 'yyyy-MM-dd'))
+    const counts = await ScheduleModel.findDailyCountByUserId(user, from, to)
+
+    const dailyCount: IDailyCountMap = {}
+
+    dates.forEach(date => {
+        dailyCount[date] = 0
+    })
+    counts.forEach(day => {
+        dailyCount[day.date] = day.count
+    })
+
+    return dailyCount
+}

--- a/packages/types/api/schedules.ts
+++ b/packages/types/api/schedules.ts
@@ -46,3 +46,14 @@ export interface IGetScheduleListResponse {
 type CalendarDate = Date | null
 
 export type CalendarDateRange = CalendarDate | [CalendarDate, CalendarDate]
+
+export interface IDailyScheduleCount {
+    date: string
+    count: number
+}
+
+export interface IDailyCountMap {
+    [date: string]: number // key: 'YYYY-MM-DD', value: count
+}
+
+export type IGetDailyScheduleCountResponse = IDailyCountMap

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -3030,6 +3033,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   date-format@4.0.14:
     resolution: {integrity: sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==}
@@ -10175,6 +10181,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@4.1.0: {}
 
   date-format@4.0.14: {}
 


### PR DESCRIPTION
각 일자별로 특정 유저의 schedule 이 존재하는지 확인하는 api 를 추가합니다.
api 응답형식은 다음과 같습니다.


```
GET http://127.0.0.1:5000/v1/schedules/dailyCount?from=2025-04-01T00:00:00.000Z&to=2025-04-30T00:00:00.000Z
{
    "2025-04-01": 3,
    "2025-04-02": 1,
    "2025-04-03": 0,
    "2025-04-04": 0,
    "2025-04-05": 0,
    .........
    "2025-04-22": 2,
    "2025-04-23": 0,
    "2025-04-24": 5,
    "2025-04-25": 0,
    "2025-04-26": 1,
    "2025-04-27": 0,
    "2025-04-28": 2,
    "2025-04-29": 0,
    "2025-04-30": 1
}
```