### PR TITLE
chore: remove unnecessary docker version tag

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -46,7 +46,6 @@ jobs:
                   tags: |
                       type=ref,event=branch
                       type=semver,pattern={{version}}
-                      type=semver,pattern={{major}}.{{minor}}
                       type=sha,prefix=,suffix=,format=short
 
             - name: Build and push Docker image


### PR DESCRIPTION
docker image 에 semver 이 기존 2개 설정되어 있었는데 1개만 사용하도록 제거합니다