### PR TITLE
fix: rerendering when calendar date changed

### DIFF
--- a/apps/web/src/components/schedules/scheduleCalendar.tsx
+++ b/apps/web/src/components/schedules/scheduleCalendar.tsx
@@ -42,6 +42,9 @@ export default function ScheduleCalendar({ setSelectedDay }: ScheduleCalendarPro
             <Calendar
                 onChange={handleChange}
                 calendarType="gregory"
+                onActiveStartDateChange={({ activeStartDate }) => {
+                    setCurrentDay(activeStartDate!)
+                }}
                 formatMonthYear={(locale, date) => {
                     const year = date.getFullYear()
                     const month = date.getMonth() + 1


### PR DESCRIPTION
캘린더 일자 변경시 데이터를 다시 가지고 오도록 수정하였습니다
기존에는 캘린더 월이 변경 되었을때 모든 일자에 개인 일정이 있는것 처럼 표시 되었으나 이제 데이터를 가지고 온 후 일정을 표시합니다

![image](https://github.com/user-attachments/assets/d2168746-5d5c-4cd4-8642-42c304ad4b40)
