### PR TITLE
fix: handle string date values correctly to avoid treating them as Date objects

### DIFF
--- a/apps/web/src/components/schedules/scheduleDetail.tsx
+++ b/apps/web/src/components/schedules/scheduleDetail.tsx
@@ -29,7 +29,8 @@ export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModa
     if (!isOpen || !schedule) return null
 
     const formatTime = (date: Date) => {
-        return `${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')} ${date.getHours() >= 12 ? 'PM' : 'AM'}`
+        const newDate = new Date(date)
+        return `${String(newDate.getMonth() + 1).padStart(2, '0')}.${String(newDate.getDate()).padStart(2, '0')} ${newDate.getHours()}:${String(newDate.getMinutes()).padStart(2, '0')} ${newDate.getHours() >= 12 ? 'PM' : 'AM'}`
     }
     const timeRange = schedule.isAllDay ? '하루 종일' : `${formatTime(schedule.startDate)} - ${formatTime(schedule.endDate)}`
 

--- a/apps/web/src/components/schedules/scheduleDetail.tsx
+++ b/apps/web/src/components/schedules/scheduleDetail.tsx
@@ -45,7 +45,6 @@ export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModa
                     </div>
                     <div className="text-sm text-gray-400 mb-4">{timeRange}</div>
                     <hr className="border-t border-gray-300 mb-4" />
-
                     <div className="mb-4 py-2">
                         <div className="flex justify-between items-center mb-1 w-full">
                             <div className="text-m text-left">장소</div>
@@ -56,7 +55,6 @@ export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModa
                             <EventMap lng={schedule.location.coordinates[0]} lat={schedule.location.coordinates[1]} />
                         </div>
                     </div>
-
                     <hr className="border-t border-gray-300 mb-4" />
                     <div className="mb-4">
                         <div className="text-m">메모</div>
@@ -64,7 +62,6 @@ export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModa
                     </div>
                     <hr className="border-t border-gray-300 mb-4" />
                 </div>
-
                 <div className="px-14 py-4">
                     <Link
                         className="block text-center bg-[#FF9575] text-white py-3 rounded-lg w-full font-semibold"

--- a/apps/web/src/components/schedules/scheduleList.tsx
+++ b/apps/web/src/components/schedules/scheduleList.tsx
@@ -59,8 +59,9 @@ export default function ScheduleList({ date }: Prop) {
     let scheduleSummary
     if (!isLoading) {
         scheduleSummary = data?.pages[0].docs?.map((doc: IScheduleItem) => {
-            const hours = new Date(doc.startDate).getHours()
-            const minutes = new Date(doc.startDate).getMinutes()
+            const newDate = new Date(doc.startDate)
+            const hours = String(newDate.getHours()).padStart(2, '0')
+            const minutes = String(newDate.getMinutes()).padStart(2, '0')
             return { id: doc._id, title: doc.name, time: `${hours}:${minutes}` }
         })
     }


### PR DESCRIPTION
현재 일정 상세조회를 클릭할 때 date.getHours 버그가 발생합니다. 이슈를 해결하기 위해 date 객체를 생성합니다.

이슈를 해결하면서 추가적으로 현재 시간을 hh:mm 형태로 출력하고 있는데, 기간이 1일을 초과하는 경우 불편함이 있을 것 같아 MM.dd hh:mm 으로 변경합니다.

추가적으로 일정리스트에서 hh:m 형태로 출력되고 있어 hh:mm이 되도록 수정합니다.