### PR TITLE
feat: display Android foreground messages as system notifications using Notifee

### DIFF
--- a/apps/app/android/app/src/main/AndroidManifest.xml
+++ b/apps/app/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
@@ -48,5 +49,12 @@
       <service
         android:name="io.invertase.firebase.messaging.ReactNativeFirebaseMessagingHeadlessService"
         android:exported="false" />
+      <receiver android:name="app.notifee.receivers.NotificationReceiver" android:exported="true" />
+      <receiver android:name="app.notifee.receivers.BootReceiver" android:enabled="true" android:exported="true">
+        <intent-filter>
+          <action android:name="android.intent.action.BOOT_COMPLETED"/>
+          <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+        </intent-filter>
+      </receiver>
     </application>
 </manifest>

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -11,6 +11,7 @@
         "test": "jest"
     },
     "dependencies": {
+        "@notifee/react-native": "^9.1.8",
         "@react-native-firebase/app": "^22.2.0",
         "@react-native-firebase/messaging": "^22.2.0",
         "@react-native-seoul/kakao-login": "^5.4.1",

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -11,8 +11,9 @@ import { NavigationContainer } from '@react-navigation/native'
 import { createNativeStackNavigator } from '@react-navigation/native-stack'
 import { Colors } from 'react-native/Libraries/NewAppScreen'
 import ErrorBoundary from 'react-native-error-boundary'
+import notifee, { AndroidImportance } from '@notifee/react-native'
 
-import { LoginScreen, RegisterScreen, WebviewScreen, ErrorScreen } from '@/pages'
+import { ErrorScreen, LoginScreen, RegisterScreen, WebviewScreen } from '@/pages'
 import { RootStackParamList } from '@/types'
 import PushNotificationService from '@/services/pushNotificationService.ts'
 import { getToken } from '@/stores'
@@ -28,6 +29,17 @@ function App(): React.JSX.Element {
     const Stack = createNativeStackNavigator<RootStackParamList>()
 
     useEffect(() => {
+        const createChannel = async () => {
+            const settings = await notifee.requestPermission()
+            if (settings.authorizationStatus >= 1) {
+                await notifee.createChannel({
+                    id: 'default',
+                    name: 'Fienmee',
+                    importance: AndroidImportance.HIGH,
+                })
+            }
+        }
+        createChannel()
         PushNotificationService.setMessageHandler()
         PushNotificationService.listenRefreshToken(async token => {
             const credential = await getToken()
@@ -40,7 +52,6 @@ function App(): React.JSX.Element {
                 },
                 accessToken: credential.accessToken,
             }
-            console.log(request)
             await submitFCMToken(request)
         })
     }, [])

--- a/apps/app/src/services/pushNotificationService.ts
+++ b/apps/app/src/services/pushNotificationService.ts
@@ -1,7 +1,8 @@
 import { AuthorizationStatus, deleteToken, getMessaging, getToken, onTokenRefresh, requestPermission } from '@react-native-firebase/messaging'
 import { getUniqueId } from 'react-native-device-info'
-import { Alert, Platform } from 'react-native'
+import { Platform } from 'react-native'
 import { INotificationToken, PlatformType } from '@fienmee/types/api/notification'
+import notifee from '@notifee/react-native'
 
 class PushNotificationService {
     private messaging = getMessaging()
@@ -47,8 +48,19 @@ class PushNotificationService {
             console.log('Background message received: ', JSON.stringify(remoteMessage))
         })
         this.messaging.onMessage(async remoteMessage => {
-            Alert.alert('Foreground message received:', JSON.stringify(remoteMessage))
-            // TODO: 알림 메시지 띄우기
+            const { title, body } = remoteMessage.notification ?? {}
+            await notifee.displayNotification({
+                title,
+                body,
+                android: {
+                    channelId: 'default',
+                    smallIcon: 'ic_launcher', // TODO: add logo img in android/app/src/main/res/drawable
+                    pressAction: {
+                        id: 'default',
+                        launchActivity: 'default',
+                    },
+                },
+            })
         })
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
 
   apps/app:
     dependencies:
+      '@notifee/react-native':
+        specifier: ^9.1.8
+        version: 9.1.8(react-native@0.76.3(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.1.2)(@types/react@18.3.12)(react@18.3.1))
       '@react-native-firebase/app':
         specifier: ^22.2.0
         version: 22.2.0(react-native@0.76.3(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.1.2)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
@@ -1769,6 +1772,11 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@notifee/react-native@9.1.8':
+    resolution: {integrity: sha512-Az/dueoPerJsbbjRxu8a558wKY+gONUrfoy3Hs++5OqbeMsR0dYe6P+4oN6twrLFyzAhEA1tEoZRvQTFDRmvQg==}
+    peerDependencies:
+      react-native: '*'
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -8947,6 +8955,10 @@ snapshots:
       fastq: 1.17.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@notifee/react-native@9.1.8(react-native@0.76.3(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.1.2)(@types/react@18.3.12)(react@18.3.1))':
+    dependencies:
+      react-native: 0.76.3(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@react-native-community/cli-server-api@15.1.2)(@types/react@18.3.12)(react@18.3.1)
 
   '@opentelemetry/api@1.9.0': {}
 


### PR DESCRIPTION
foreground message( 앱이 실행 중일 때 푸시메시지가 도착한 경우)에는 시스템에서 자동으로 메시지를 표시하지 않기 때문에 Notifee를 이용해 시스템 메시지를 만들도록 합니다. 

안드로이드에서 환경설정만 작성했음으로 이후 ios 관련 세팅이 추가적으로 필요합니다. 