### PR TITLE
feat: add horizontal slide navigation in schedule detail modal

### DIFF
--- a/apps/web/src/components/events/eventTimeSelector.tsx
+++ b/apps/web/src/components/events/eventTimeSelector.tsx
@@ -20,7 +20,7 @@ const EventTimeSelector: React.FC<EventTimeSelectorProps> = ({
 }) => {
     return (
         <div>
-            <div className="border rounded-lg p-4">
+            <div className="border rounded-lg px-2 py-4">
                 <div className="flex items-center justify-between mb-4">
                     <span className="text-sm text-gray-700 font-medium">하루 종일</span>
                     <button
@@ -35,12 +35,12 @@ const EventTimeSelector: React.FC<EventTimeSelectorProps> = ({
 
                 <div className="flex flex-col gap-3">
                     <div className="flex items-center justify-between">
-                        <label className="text-sm font-medium w-[50px]">시작</label>
+                        <label className="text-sm font-medium w-[2.5rem] whitespace-nowrap">시작</label>
                         <DateTimeInput value={initStartDate} onChange={onStartDateChange} hideTime={isAllDay} />
                     </div>
 
                     <div className="flex items-center justify-between">
-                        <label className="text-sm font-medium w-[50px]">종료</label>
+                        <label className="text-sm font-medium w-[2.5rem] whitespace-nowrap">종료</label>
                         <DateTimeInput value={initEndDate} onChange={onEndDateChange} hideTime={isAllDay} />
                     </div>
                 </div>

--- a/apps/web/src/components/schedules/scheduleDetail.tsx
+++ b/apps/web/src/components/schedules/scheduleDetail.tsx
@@ -1,9 +1,12 @@
-import { IScheduleItem } from '@fienmee/types'
-import { EventMap } from '@/components/events/eventMap'
 import Link from 'next/link'
-import { eventStore } from '@/store'
+import { format } from 'date-fns'
+
+import { IScheduleItem } from '@fienmee/types'
 import { getEventDetail } from '@/api/event'
+import { EventMap } from '@/components/events/eventMap'
 import ScheduleOption from '@/components/schedules/scheduleOption'
+import { eventStore } from '@/store'
+import React, { useRef, useState } from 'react'
 
 interface ScheduleDetailModalProps {
     isOpen: boolean
@@ -11,9 +14,13 @@ interface ScheduleDetailModalProps {
     schedule: IScheduleItem
     setModalType: (type: string) => void
     openDeleteModal: () => void
+    onPrev: () => void
+    onNext: () => void
 }
 
-export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModalType, openDeleteModal }: ScheduleDetailModalProps) {
+export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModalType, openDeleteModal, onNext, onPrev }: ScheduleDetailModalProps) {
+    const dragStartX = useRef<number | null>(null)
+    const [dragX, setDragX] = useState(0)
     const { setEvent } = eventStore()
 
     const onClick = async (eventId: string) => {
@@ -27,49 +34,85 @@ export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModa
         }
     }
 
+    const hanldeTouchStart = (e: React.TouchEvent) => {
+        dragStartX.current = e.touches[0].clientX
+    }
+
+    const handleTouchMove = (e: React.TouchEvent) => {
+        if (dragStartX.current === null) {
+            return
+        }
+        const currentX = e.touches[0].clientX
+        setDragX(currentX - dragStartX.current)
+    }
+
+    const handleTouchEnd = () => {
+        if (dragX >= 40) {
+            onPrev()
+        } else if (dragX <= -40) {
+            onNext()
+        }
+        setDragX(0)
+        dragStartX.current = null
+    }
+
     if (!isOpen || !schedule) return null
 
     const formatTime = (date: Date) => {
         const newDate = new Date(date)
-        return `${String(newDate.getMonth() + 1).padStart(2, '0')}.${String(newDate.getDate()).padStart(2, '0')} ${newDate.getHours()}:${String(newDate.getMinutes()).padStart(2, '0')} ${newDate.getHours() >= 12 ? 'PM' : 'AM'}`
+        return format(newDate, 'MM.dd HH:mm a')
     }
     const timeRange = schedule.isAllDay ? '하루 종일' : `${formatTime(schedule.startDate)} - ${formatTime(schedule.endDate)}`
 
     return (
-        <div className="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-end" onClick={handleBackdropClick}>
-            <div className="bg-white w-full h-[70%] rounded-t-2xl shadow-lg overflow-y-auto flex flex-col">
-                <div className="p-10 flex-1 overflow-auto">
-                    <div className="flex items-center justify-between mb-2">
-                        <div className="text-lg font-semibold">{schedule.name}</div>
-                        <ScheduleOption onEdit={() => setModalType('update')} onDelete={openDeleteModal} />
-                    </div>
-                    <div className="text-sm text-gray-400 mb-4">{timeRange}</div>
-                    <hr className="border-t border-gray-300 mb-4" />
-                    <div className="mb-4 py-2">
-                        <div className="flex justify-between items-center mb-1 w-full">
-                            <div className="text-m text-left">장소</div>
-                            <div className="text-base font-semibold text-right">{schedule.address}</div>
+        <div className="flex fixed inset-0 bg-black bg-opacity-40 z-50 items-end" onClick={handleBackdropClick}>
+            <div className="relative w-full h-[70%] overflow-hidden">
+                <div
+                    className="absolute grid grid-cols-5 w-[150%] h-full justify-between gap-2 -left-[25%]"
+                    style={{
+                        transform: `translateX(${dragX > 0 ? Math.min(40, dragX) : Math.max(-40, dragX)}px)`,
+                        transition: dragX === 0 ? 'transform 0.3s ease' : 'none',
+                    }}
+                    onTouchMove={handleTouchMove}
+                    onTouchStart={hanldeTouchStart}
+                    onTouchEnd={handleTouchEnd}
+                >
+                    <div className="bg-white w-full h-full rounded-t-2xl shadow-lg" />
+                    <div className="col-span-3 flex flex-col bg-white w-full h-full rounded-t-2xl shadow-lg overflow-auto">
+                        <div className="py-10 px-8 flex-1 overflow-auto">
+                            <div className="flex items-center justify-between mb-2">
+                                <div className="text-lg font-semibold">{schedule.name}</div>
+                                <ScheduleOption onEdit={() => setModalType('update')} onDelete={openDeleteModal} />
+                            </div>
+                            <div className="text-sm text-gray-400 mb-4">{timeRange}</div>
+                            <hr className="border-t border-gray-300 mb-4" />
+                            <div className="mb-4 py-2">
+                                <div className="flex justify-between items-start mb-1 w-full">
+                                    <div className="text-left whitespace-nowrap">장소</div>
+                                    <div className="font-semibold text-right whitespace-break-spaces">{schedule.address}</div>
+                                </div>
+                                <div className="mt-2 border border-gray-200 rounded-lg h-32 overflow-hidden">
+                                    <EventMap lng={schedule.location.coordinates[0]} lat={schedule.location.coordinates[1]} />
+                                </div>
+                            </div>
+                            <hr className="border-t border-gray-300 mb-4" />
+                            <div className="mb-4">
+                                <div className="text-m">메모</div>
+                                <div className="text-sm text-gray-500 whitespace-pre-line">{schedule.description || '작성된 메모가 없습니다.'}</div>
+                            </div>
+                            <hr className="border-t border-gray-300 mb-4" />
                         </div>
-
-                        <div className="mt-2 border border-gray-200 rounded-lg h-32 overflow-hidden">
-                            <EventMap lng={schedule.location.coordinates[0]} lat={schedule.location.coordinates[1]} />
+                        <div className="px-14 py-4">
+                            <Link
+                                className="block text-center bg-[#FF9575] text-white py-3 rounded-lg w-full font-semibold"
+                                href={`/events/detail`}
+                                onClick={() => onClick(schedule.eventId)}
+                            >
+                                행사 더 자세히 보러 가기
+                            </Link>
                         </div>
                     </div>
-                    <hr className="border-t border-gray-300 mb-4" />
-                    <div className="mb-4">
-                        <div className="text-m">메모</div>
-                        <div className="text-sm text-gray-500 whitespace-pre-line">{schedule.description || '작성된 메모가 없습니다.'}</div>
-                    </div>
-                    <hr className="border-t border-gray-300 mb-4" />
-                </div>
-                <div className="px-14 py-4">
-                    <Link
-                        className="block text-center bg-[#FF9575] text-white py-3 rounded-lg w-full font-semibold"
-                        href={`/events/detail`}
-                        onClick={() => onClick(schedule.eventId)}
-                    >
-                        행사 더 자세히 보러 가기
-                    </Link>
+                    <div className="bg-white w-full h-full rounded-t-2xl shadow-lg" />
                 </div>
             </div>
         </div>

--- a/apps/web/src/components/schedules/scheduleDetail.tsx
+++ b/apps/web/src/components/schedules/scheduleDetail.tsx
@@ -1,3 +1,4 @@
+import React, { useRef, useState } from 'react'
 import Link from 'next/link'
 import { format } from 'date-fns'
 
@@ -6,7 +7,6 @@ import { getEventDetail } from '@/api/event'
 import { EventMap } from '@/components/events/eventMap'
 import ScheduleOption from '@/components/schedules/scheduleOption'
 import { eventStore } from '@/store'
-import React, { useRef, useState } from 'react'
 
 interface ScheduleDetailModalProps {
     isOpen: boolean

--- a/apps/web/src/components/schedules/scheduleDetail.tsx
+++ b/apps/web/src/components/schedules/scheduleDetail.tsx
@@ -34,7 +34,7 @@ export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModa
         }
     }
 
-    const hanldeTouchStart = (e: React.TouchEvent) => {
+    const handleTouchStart = (e: React.TouchEvent) => {
         dragStartX.current = e.touches[0].clientX
     }
 
@@ -74,7 +74,7 @@ export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModa
                         transition: dragX === 0 ? 'transform 0.3s ease' : 'none',
                     }}
                     onTouchMove={handleTouchMove}
-                    onTouchStart={hanldeTouchStart}
+                    onTouchStart={handleTouchStart}
                     onTouchEnd={handleTouchEnd}
                 >
                     <div className="bg-white w-full h-full rounded-t-2xl shadow-lg" />

--- a/apps/web/src/components/schedules/scheduleItem.tsx
+++ b/apps/web/src/components/schedules/scheduleItem.tsx
@@ -1,14 +1,20 @@
+import { format } from 'date-fns'
+
 interface ScheduleProp {
-    time: string
+    startDate: Date
+    endDate: Date
     title: string
     onClick?: () => void
 }
 
-export default function ScheduleItem({ time, title, onClick }: ScheduleProp) {
+export default function ScheduleItem({ startDate, endDate, title, onClick }: ScheduleProp) {
+    const formatTime = (date: Date) => {
+        return format(date, 'MM.dd HH:mm a')
+    }
     return (
-        <div className="grid grid-cols-5 divide-x-1" onClick={onClick}>
-            <div className="col-span-1 pr-4 m-4 border-r-2 border-r-gray-500">{time}</div>
-            <div className="col-span-4 m-4">{title}</div>
+        <div className="flex flex-col" onClick={onClick}>
+            <div className="text-lg text-[#1B1B1B] p-4 pb-1">{title}</div>
+            <div className="text-base text-[#B8BABB] px-4 pb-1">{`${formatTime(startDate)} - ${formatTime(endDate)}`}</div>
         </div>
     )
 }

--- a/apps/web/src/components/schedules/scheduleList.tsx
+++ b/apps/web/src/components/schedules/scheduleList.tsx
@@ -1,9 +1,10 @@
-import ScheduleItem from '@/components/schedules/scheduleItem'
-import { useInfiniteQuery } from '@tanstack/react-query'
-import { getSchedulesByDate } from '@/api/schedules'
-import { useInView } from 'react-intersection-observer'
 import { useEffect, useState } from 'react'
-import { IScheduleItem } from '@fienmee/types'
+import { useInView } from 'react-intersection-observer'
+import { ClipLoader } from 'react-spinners'
+import { useInfiniteQuery } from '@tanstack/react-query'
+
+import { getSchedulesByDate } from '@/api/schedules'
+import ScheduleItem from '@/components/schedules/scheduleItem'
 import ScheduleDetailModal from '@/components/schedules/scheduleDetail'
 import ScheduleUpdateModal from '@/components/schedules/scheduleUpdate'
 import ScheduleDeleteModal from '@/components/schedules/scheduleDeleteModal'
@@ -13,32 +14,60 @@ interface Prop {
     date: Date
 }
 
-interface IScheduleSummary {
-    id: string
-    title: string
-    time: string
-}
-
 export default function ScheduleList({ date }: Prop) {
-    const { data, isLoading, isError, fetchNextPage } = useSchedulesByDate({ date: date, startPage: 1, limit: 5 })
+    const { data, isLoading, isError, fetchNextPage, isFetchingNextPage } = useSchedulesByDate({ date: date, startPage: 1, limit: 5 })
     const { ref, inView } = useInView()
     const [isModalOpen, setIsModalOpen] = useState(false)
-    const { schedule, setSchedule } = scheduleStore()
     const [modalType, setModalType] = useState<string>('none')
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+    const [index, setIndex] = useState<number[]>([0, 0])
+    const { schedule, setSchedule } = scheduleStore()
 
     useEffect(() => {
-        if (inView) {
+        if (inView && !isFetchingNextPage) {
             fetchNextPage()
         }
     }, [inView, fetchNextPage])
 
-    const handleClick = (scheduleId: string) => {
-        const selectedSchedule = data?.pages[0].docs?.find((doc: IScheduleItem) => doc._id === scheduleId)
-        if (selectedSchedule) {
-            setSchedule(selectedSchedule)
+    const handleClick = (i: number, j: number) => {
+        setIndex([i, j])
+        const schedule = data?.pages[i].docs[j]
+        if (schedule) {
+            setSchedule(schedule)
             setIsModalOpen(true)
             setModalType('detail')
+        }
+    }
+
+    const handleNext = () => {
+        let [i, j] = index
+        const curDocs = data?.pages[i]
+        if (curDocs) {
+            if (j < curDocs.limit - 1) {
+                j++
+            } else if (i < data.pages.length - 1) {
+                i++
+                j = 0
+            } else {
+                return
+            }
+            handleClick(i, j)
+        }
+    }
+
+    const handlePrev = () => {
+        let [i, j] = index
+        const curDocs = data?.pages[i]
+        if (curDocs) {
+            if (j > 0) {
+                j--
+            } else if (i > 0) {
+                i--
+                j = data?.pages[i].docs.length - 1
+            } else {
+                return
+            }
+            handleClick(i, j)
         }
     }
 
@@ -59,26 +88,42 @@ export default function ScheduleList({ date }: Prop) {
         )
     }
 
-    let scheduleSummary
-    if (!isLoading) {
-        scheduleSummary = data?.pages[0].docs?.map((doc: IScheduleItem) => {
-            const newDate = new Date(doc.startDate)
-            const hours = String(newDate.getHours()).padStart(2, '0')
-            const minutes = String(newDate.getMinutes()).padStart(2, '0')
-            return { id: doc._id, title: doc.name, time: `${hours}:${minutes}` }
-        })
+    if (isLoading) {
+        return (
+            <div className="bg-white w-full border-t border-t-[#E4E4E4]">
+                <div className="ml-5 mt-6 mb-3 text-xl font-bold text-left">{String(date.getDate()).padStart(2, '0')}일 일정</div>
+                <div className="flex justify-center">
+                    <ClipLoader color="#FF6B6B" size={50} />
+                </div>
+            </div>
+        )
     }
 
     return (
-        <div className="bg-white w-full border-t border-t-[#E4E4E4]">
-            <div className="ml-5 mt-6 mb-3 text-xl font-bold text-left">{String(date.getDate()).padStart(2, '0')}일 일정</div>
-            <div>
-                {scheduleSummary &&
-                    scheduleSummary.map((schedule: IScheduleSummary) => (
-                        <ScheduleItem key={schedule.id} {...schedule} onClick={() => handleClick(schedule.id)} />
-                    ))}
+        <div className="bg-white w-full border-t border-t-[#E4E4E4] pb-3">
+            <div className="text-xl font-bold text-left px-4 pb-3 pt-6">{String(date.getDate()).padStart(2, '0')}일 일정</div>
+            <div className="flex flex-col">
+                {data &&
+                    data.pages.map((docs, i) =>
+                        docs.docs.map((schedule, j) => (
+                            <ScheduleItem
+                                key={schedule._id}
+                                title={schedule.name}
+                                startDate={schedule.startDate}
+                                endDate={schedule.endDate}
+                                onClick={() => handleClick(i, j)}
+                            />
+                        )),
+                    )}
             </div>
-            <div ref={ref}></div>
+            {isFetchingNextPage ? (
+                <div className="bg-white p-4 animate-pulse">
+                    <div className="w-full h-6 bg-[#D9D9D9] my-2 rounded-lg" />
+                    <div className="w-2/3 h-3 bg-[#D9D9D9] my-2 rounded-lg" />
+                </div>
+            ) : (
+                <div ref={ref} />
+            )}
 
             {modalType === 'detail' && (
                 <ScheduleDetailModal
@@ -87,6 +132,8 @@ export default function ScheduleList({ date }: Prop) {
                     schedule={schedule}
                     setModalType={setModalType}
                     openDeleteModal={() => setIsDeleteModalOpen(true)}
+                    onNext={() => handleNext()}
+                    onPrev={() => handlePrev()}
                 />
             )}
 

--- a/apps/web/src/components/schedules/scheduleList.tsx
+++ b/apps/web/src/components/schedules/scheduleList.tsx
@@ -43,7 +43,7 @@ export default function ScheduleList({ date }: Prop) {
         let [i, j] = index
         const curDocs = data?.pages[i]
         if (curDocs) {
-            if (j < curDocs.limit - 1) {
+            if (j < curDocs.docs.length - 1) {
                 j++
             } else if (i < data.pages.length - 1) {
                 i++

--- a/apps/web/src/components/schedules/scheduleUpdate.tsx
+++ b/apps/web/src/components/schedules/scheduleUpdate.tsx
@@ -50,75 +50,85 @@ export default function ScheduleUpdateModal({ isOpen, onClose, initSchedule, set
     if (!isOpen || !schedule) return null
 
     return (
-        <div className="fixed inset-0 bg-black bg-opacity-40 z-50 flex items-end" onClick={handleBackdropClick}>
-            <div className="bg-white w-full h-[70%] rounded-t-2xl shadow-lg overflow-y-auto flex flex-col">
-                <div className="p-10 flex-1 overflow-auto">
-                    <div className="mb-4">
-                        <InputField
-                            label="일정 이름"
-                            placeholder="일정 이름을 입력해주세요"
-                            value={schedule.name}
-                            name="name"
-                            onChange={handleChange}
-                        />
-                    </div>
-                    <hr className="border-t border-gray-300 mb-4" />
-
-                    <div className="text-m text-left">일정 시간</div>
-                    <EventTimeSelector
-                        isAllDay={schedule.isAllDay}
-                        toggleAllDay={() => setScheduleForm({ ...schedule, isAllDay: !schedule.isAllDay })}
-                        initStartDate={schedule.startDate}
-                        initEndDate={schedule.endDate}
-                        onStartDateChange={onStartDateTimeChange}
-                        onEndDateChange={onEndDateTimeChange}
-                    />
-                    <div className="mb-4 py-2">
-                        <div className="mt-2 mb-4">
-                            <InputField
-                                label="장소"
-                                placeholder="장소를 입력해주세요"
-                                value={schedule.address}
-                                name="address"
-                                onChange={handleChange}
+        <div className="flex fixed inset-0 bg-black bg-opacity-40 z-50 items-end" onClick={handleBackdropClick}>
+            <div className="relative w-full h-[70%] overflow-hidden">
+                <div className="absolute grid grid-cols-5 w-[150%] h-full justify-between gap-2 -left-[25%]">
+                    <div className="bg-white w-full h-full rounded-t-2xl shadow-lg" />
+                    <div className="col-span-3 flex flex-col bg-white w-full h-full rounded-t-2xl shadow-lg overflow-auto">
+                        <div className="py-10 px-8 flex-1 overflow-auto">
+                            <div className="mb-4">
+                                <InputField
+                                    label="일정 이름"
+                                    placeholder="일정 이름을 입력해주세요"
+                                    value={schedule.name}
+                                    name="name"
+                                    onChange={handleChange}
+                                />
+                            </div>
+                            <hr className="border-t border-gray-300 mb-4" />
+                            <div className="text-m text-left">일정 시간</div>
+                            <EventTimeSelector
+                                isAllDay={schedule.isAllDay}
+                                toggleAllDay={() => setScheduleForm({ ...schedule, isAllDay: !schedule.isAllDay })}
+                                initStartDate={schedule.startDate}
+                                initEndDate={schedule.endDate}
+                                onStartDateChange={onStartDateTimeChange}
+                                onEndDateChange={onEndDateTimeChange}
                             />
+                            <div className="mb-4 py-2">
+                                <div className="mt-2 mb-4">
+                                    <InputField
+                                        label="장소"
+                                        placeholder="장소를 입력해주세요"
+                                        value={schedule.address}
+                                        name="address"
+                                        onChange={handleChange}
+                                    />
+                                </div>
+                                <div className="mt-2 border border-gray-200 rounded-lg h-32 overflow-hidden">
+                                    <EventVenueSelector
+                                        initialPosition={{
+                                            lat: schedule.location.coordinates[1],
+                                            lng: schedule.location.coordinates[0],
+                                        }}
+                                        onPositionChange={newPosition =>
+                                            setScheduleForm(prev => ({
+                                                ...prev!,
+                                                location: {
+                                                    type: 'Point',
+                                                    coordinates: [newPosition.lng, newPosition.lat],
+                                                },
+                                            }))
+                                        }
+                                    />
+                                </div>
+                            </div>
+
+                            <hr className="border-t border-gray-300 mb-4" />
+                            <div className="mb-4">
+                                <InputField
+                                    label="메모"
+                                    placeholder="일정에 대한 메모를 작성해주세요"
+                                    value={schedule.description}
+                                    type="textarea"
+                                    rows={4}
+                                    name="description"
+                                    onChange={handleChange}
+                                />
+                            </div>
+                            <hr className="border-t border-gray-300 mb-4" />
+
+                            <div className="px-14 py-4">
+                                <button
+                                    className="block text-center bg-[#FF9575] text-white py-3 rounded-lg w-full font-semibold"
+                                    onClick={() => onClick()}
+                                >
+                                    저장하기
+                                </button>
+                            </div>
                         </div>
-
-                        <div className="mt-2 border border-gray-200 rounded-lg h-32 overflow-hidden">
-                            <EventVenueSelector
-                                initialPosition={{ lat: schedule.location.coordinates[1], lng: schedule.location.coordinates[0] }}
-                                onPositionChange={newPosition =>
-                                    setScheduleForm(prev => ({
-                                        ...prev!,
-                                        location: {
-                                            type: 'Point',
-                                            coordinates: [newPosition.lng, newPosition.lat],
-                                        },
-                                    }))
-                                }
-                            />
-                        </div>
                     </div>
-
-                    <hr className="border-t border-gray-300 mb-4" />
-                    <div className="mb-4">
-                        <InputField
-                            label="메모"
-                            placeholder="일정에 대한 메모를 작성해주세요"
-                            value={schedule.description}
-                            type="textarea"
-                            rows={4}
-                            name="description"
-                            onChange={handleChange}
-                        />
-                    </div>
-                    <hr className="border-t border-gray-300 mb-4" />
-
-                    <div className="px-14 py-4">
-                        <button className="block text-center bg-[#FF9575] text-white py-3 rounded-lg w-full font-semibold" onClick={() => onClick()}>
-                            저장하기
-                        </button>
-                    </div>
+                    <div className="bg-white w-full h-full rounded-t-2xl shadow-lg" />
                 </div>
             </div>
         </div>

--- a/apps/web/src/components/schedules/scheduleUpdate.tsx
+++ b/apps/web/src/components/schedules/scheduleUpdate.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { IScheduleItem } from '@fienmee/types'
+
 import { updateSchedule } from '@/api/schedules'
 import EventTimeSelector from '@/components/events/eventTimeSelector'
 import InputField from '@/components/events/inputField'


### PR DESCRIPTION
## 변경사항
+ 일정 상세보기에서 좌우 슬라이드로 이전, 이후 schedule을 가져올 수 있도록 합니다. 
+ 일정 상세보기의 화면과 동일하게 update modal의 UI를 조정합니다.
+ figma와 동일하게 UI 간격 조정을 합니다.

## UI/UX 보기
![image](https://github.com/user-attachments/assets/ae8f11a8-2827-420c-97a9-2bfe55417f88)
