### PR TITLE
fix: immediately refetch comments after submission to update the view

### DIFF
--- a/apps/web/src/components/comment/commentList.tsx
+++ b/apps/web/src/components/comment/commentList.tsx
@@ -70,5 +70,6 @@ const useCommentsQuery = ({ eventId, startPage }: UseCommentsQueryProps) => {
             }
             return undefined
         },
+        staleTime: 1000 * 30,
     })
 }


### PR DESCRIPTION
현재 댓글을 등록하면 화면에 즉각 보이지 않고, 다시 eventDetail 페이지를 방문해도 댓글 목록이 갱신되지 않습니다. 이 문제를 해결하고자 다음과 같이 수정합니다.
+ 댓글 등록시 mutation을 이용하고, 성공 시 invalidateQueries를 이용해 댓글 목록을 갱신하도록 합니다.
+ 댓글 목록의 staleTime을 기본값이 아닌 30초로 변경하면서 다른 기기에서도 댓글 목록을 빠르게 갱신할 수 있도록 합니다. 
  + 30초로 선정한 이유는 0초로 하면 불필요한 갱신이 많이 반복되고, 60초 이상일 시 갱신이 비교적 느리게 갱신될 것으로 판단되어 30초로 선정하였습니다. 