### PR TITLE
feat: enable comment editing on frontend

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -105,8 +105,13 @@ router.get('/:id/comments', verifyToken, async (req: Request, res: Response) => 
         limit: Number(req.query.limit) || 10,
     }
     const result = await CommentsModel.findByEventId(req.params.id, options)
+    const modifiedDocs = result.docs.map(comment => ({
+        ...comment.toJSON(),
+        isAuthor: comment.get('userId')?.equals(req.user._id),
+        // TODO: add isLiked field
+    }))
     res.status(200).json({
-        comments: result.docs,
+        comments: modifiedDocs,
         page: {
             totalDocs: result.totalDocs,
             totalPages: result.totalPages,

--- a/apps/server/src/models/comments.ts
+++ b/apps/server/src/models/comments.ts
@@ -46,8 +46,8 @@ export class Comments extends defaultClasses.TimeStamps {
             page: number
             limit: number
         },
-    ) {
-        return this.paginate({ eventId: eventId }, options)
+    ): Promise<mongoose.PaginateResult<mongoose.PaginateDocument<typeof Comments, object, object, mongoose.PaginateOptions>>> {
+        return await this.paginate({ eventId: eventId }, options)
     }
 }
 

--- a/apps/web/src/api/event.ts
+++ b/apps/web/src/api/event.ts
@@ -6,6 +6,7 @@ import {
     IPostEventRequest,
     IPutEventRequest,
     IGetEventCommentsResponse,
+    IPutEventCommentRequest,
 } from '@fienmee/types'
 
 import { SERVER_URL } from '@/config'
@@ -80,6 +81,17 @@ export async function registerEventComments(request: IPostEventCommentRequest) {
     const res = await fetch(`${SERVER_URL}/v1/events/${request.eventId}/comments`, {
         method: 'POST',
         body: JSON.stringify({ comment: request.comment }),
+    })
+    if (!res.ok) {
+        throw await res.json()
+    }
+    return
+}
+
+export async function updateEventComment(request: IPutEventCommentRequest) {
+    const res = await fetch(`${SERVER_URL}/v1/events/${request.uri.eventId}/comments/${request.uri.commentId}`, {
+        method: 'PUT',
+        body: JSON.stringify(request.body),
     })
     if (!res.ok) {
         throw await res.json()

--- a/apps/web/src/components/comment/comment.tsx
+++ b/apps/web/src/components/comment/comment.tsx
@@ -1,20 +1,30 @@
-import { UnlikeIcon } from '@/components/icon'
+import { useState } from 'react'
 import { IComment } from '@fienmee/types'
+
+import CommentOption from '@/components/comment/commentOption'
+import CommentUpdateField from '@/components/comment/commentUpdateField'
+import { UnlikeIcon } from '@/components/icon'
 
 interface Props {
     comment: IComment
 }
 
 export function EventComment({ comment }: Props) {
+    const [isEdit, setIsEdit] = useState<boolean>(false)
     return (
-        <div className="flex flex-col gap-6 px-4 py-2">
-            <div className="flex justify-between items-start">
+        <div className="flex flex-col gap-6 py-2 relative">
+            <div className="flex justify-between items-center">
                 <div>
                     <div className="text-sm text-gray-500">{comment.nickname}</div>
-                    <div className="text-base text-gray-900">{comment.comment}</div>
+                    {isEdit ? (
+                        <CommentUpdateField comment={comment} onSuccess={() => setIsEdit(false)} />
+                    ) : (
+                        <div className="text-base text-gray-900">{comment.comment}</div>
+                    )}
                 </div>
-                <div className="self-center">
+                <div className="flex flex-row justify-center items-center gap-2">
                     <UnlikeIcon width="1.5rem" height="1.25rem" />
+                    {comment.isAuthor && <CommentOption onEdit={() => setIsEdit(true)} />}
                 </div>
             </div>
         </div>

--- a/apps/web/src/components/comment/commentOption.tsx
+++ b/apps/web/src/components/comment/commentOption.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import Dropdown from '@/components/dropdown'
+import { OptionIcon } from '@/components/icon'
+
+interface Props {
+    onEdit: () => void
+}
+
+export default function CommentOption({ onEdit }: Props) {
+    return (
+        <Dropdown Icon={() => OptionIcon({ width: '1.5rem', height: '1.5rem' })} xTranslate={'-translate-x-20'}>
+            <button className="block w-24 p-3 border-b border-gray-200" onClick={onEdit}>
+                수정하기
+            </button>
+        </Dropdown>
+    )
+}

--- a/apps/web/src/components/comment/commentUpdateField.tsx
+++ b/apps/web/src/components/comment/commentUpdateField.tsx
@@ -25,7 +25,7 @@ export default function CommentUpdateField({ comment, onSuccess }: Props) {
         return () => {
             document.removeEventListener('mousedown', handleClickOutside)
         }
-    }, [])
+    }, [onSuccess])
 
     const mutation = useMutation({
         mutationFn: (request: IPutEventCommentRequest) => {

--- a/apps/web/src/components/comment/commentUpdateField.tsx
+++ b/apps/web/src/components/comment/commentUpdateField.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { toast } from 'react-toastify'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import { IComment, IPutEventCommentRequest } from '@fienmee/types'
+import { updateEventComment } from '@/api/event'
+
+interface Props {
+    comment: IComment
+    onSuccess: () => void
+}
+export default function CommentUpdateField({ comment, onSuccess }: Props) {
+    const [body, setBody] = useState<string>(comment.comment)
+    const queryClient = useQueryClient()
+    const ref = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (ref.current && !ref.current.contains(event.target as Node)) {
+                onSuccess()
+            }
+        }
+
+        document.addEventListener('mousedown', handleClickOutside)
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside)
+        }
+    }, [])
+
+    const mutation = useMutation({
+        mutationFn: (request: IPutEventCommentRequest) => {
+            return updateEventComment(request)
+        },
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: ['comments', comment.eventId] })
+            setBody('')
+            onSuccess()
+            toast.success(
+                <span>
+                    댓글 수정에 성공하였습니다.
+                    <span style={{ fontSize: 0 }}>{Date.now()}</span>
+                </span>,
+            )
+        },
+        onError: () => {
+            toast.error(
+                <span>
+                    댓글 수정에 실패했습니다.
+                    <span style={{ fontSize: 0 }}>{Date.now()}</span>
+                </span>,
+            )
+        },
+    })
+
+    const handleSubmit = () => {
+        if (body.trim() === '') {
+            toast.error(
+                <span>
+                    공백만 입력할 수 없습니다.
+                    <span style={{ fontSize: 0 }}>{Date.now()}</span>
+                </span>,
+            )
+            return
+        }
+        const request: IPutEventCommentRequest = {
+            uri: {
+                eventId: comment.eventId,
+                commentId: comment._id,
+            },
+            body: {
+                comment: body,
+            },
+        }
+        mutation.mutate(request)
+    }
+
+    return (
+        <div className="flex h-10 w-full items-center justify-center gap-2" ref={ref}>
+            <textarea
+                className="border w-full h-full rounded-full text-sm self-center px-4 py-2"
+                placeholder="댓글을 입력해주세요."
+                value={body}
+                onChange={e => setBody(e.target.value)}
+            />
+            <button
+                className="bg-[#FF9575] text-white text-base px-4 h-10 rounded-lg flex items-center justify-center min-w-[60px]"
+                onClick={handleSubmit}
+            >
+                수정
+            </button>
+        </div>
+    )
+}

--- a/apps/web/src/components/comment/commentUpdateField.tsx
+++ b/apps/web/src/components/comment/commentUpdateField.tsx
@@ -35,31 +35,16 @@ export default function CommentUpdateField({ comment, onSuccess }: Props) {
             await queryClient.invalidateQueries({ queryKey: ['comments', comment.eventId] })
             setBody('')
             onSuccess()
-            toast.success(
-                <span>
-                    댓글 수정에 성공하였습니다.
-                    <span style={{ fontSize: 0 }}>{Date.now()}</span>
-                </span>,
-            )
+            toast.success(<span>댓글 수정에 성공하였습니다.</span>)
         },
         onError: () => {
-            toast.error(
-                <span>
-                    댓글 수정에 실패했습니다.
-                    <span style={{ fontSize: 0 }}>{Date.now()}</span>
-                </span>,
-            )
+            toast.error(<span>댓글 수정에 실패했습니다.</span>)
         },
     })
 
     const handleSubmit = () => {
         if (body.trim() === '') {
-            toast.error(
-                <span>
-                    공백만 입력할 수 없습니다.
-                    <span style={{ fontSize: 0 }}>{Date.now()}</span>
-                </span>,
-            )
+            toast.error(<span>공백만 입력할 수 없습니다.</span>)
             return
         }
         const request: IPutEventCommentRequest = {

--- a/packages/types/api/events.ts
+++ b/packages/types/api/events.ts
@@ -89,11 +89,25 @@ export interface IPostEventCommentRequest {
     comment: string
 }
 
+export interface IPutEventCommentRequest {
+    uri: {
+        eventId: string
+        commentId: string
+    }
+    body: {
+        comment: string
+    }
+}
+
 export interface IComment {
     _id: string
+    userId: string
     eventId: string
     comment: string
     nickname: string
+    createdAt: Date
+    updatedAt: Date
+    isAuthor: boolean
 }
 
 export interface IGetEventCommentsResponse {

--- a/packages/types/api/events.ts
+++ b/packages/types/api/events.ts
@@ -101,13 +101,12 @@ export interface IPutEventCommentRequest {
 
 export interface IComment {
     _id: string
-    userId: string
     eventId: string
     comment: string
     nickname: string
+    isAuthor: boolean
     createdAt: Date
     updatedAt: Date
-    isAuthor: boolean
 }
 
 export interface IGetEventCommentsResponse {


### PR DESCRIPTION
댓글 수정이 가능하도록 FE에 로직을 추가합니다.

- 댓글 옵션을 클릭할 수 있도록 `isAuthor` field를 comment에 추가합니다.  
- 댓글 수정이 가능하도록 UI를 추가합니다.

<div style="display: flex; gap: 1rem;">
  <img src="https://github.com/user-attachments/assets/4fcd24d5-73f5-4948-a2fc-3a37dcf1738b" width="300" />
  <img src="https://github.com/user-attachments/assets/8d7f5999-6a7e-47eb-a688-6760ce0c86cf" width="300" />
</div>
