### PR TITLE
fix: prevent creating notification when event.authorId is missing

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -87,7 +87,7 @@ router.post('/:id/comments', verifyToken, async (req: Request, res: Response) =>
     })
 
     const event = await EventsModel.findByIdAndUpdate(req.params.id, { $push: { comments: comment._id } })
-    if (!event.authorId.equals(req.user._id)) {
+    if (event.authorId && !event.authorId.equals(req.user._id)) {
         await NotificationModel.createAndSendNotification(
             NotificationType.COMMENT,
             event.authorId,
@@ -159,7 +159,7 @@ router.post('/:id/likes', verifyToken, async (req: Request, res: Response) => {
     const update = prevLiked ? { $pull: { likes: req.user._id } } : { $push: { likes: req.user._id } }
 
     await EventsModel.updateOne({ _id: req.params.id }, update)
-    if (!event.authorId.equals(req.user._id) && !prevLiked) {
+    if (event.authorId && !prevLiked && !event.authorId.equals(req.user._id)) {
         await NotificationModel.createAndSendNotification(
             NotificationType.LIKE,
             event.authorId,
@@ -182,7 +182,7 @@ router.post('/:id/reviews', verifyToken, async (req: Request, res: Response) => 
         body: req.body.body,
     })
 
-    if (!event.authorId.equals(req.user._id)) {
+    if (event.authorId && !event.authorId.equals(req.user._id)) {
         await NotificationModel.createAndSendNotification(
             NotificationType.REVIEW,
             event.authorId,


### PR DESCRIPTION
스케쥴러에 의해 생성된 행사(공공 데이터 활용)은 authorId 필드가 없어 notification 생성에서 실행 오류가 발생합니다. 이를 해결하기 위해 authorId 검증 로직을 추가합니다.