### PR TITLE
feat: add middleware to verify event author for update and delete APIs

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -15,7 +15,7 @@ router.post('/category/initialize', async (req: Request, res: Response) => {
     res.sendStatus(204)
 })
 
-router.get('/categories', verifyToken, async (req: Request, res: Response) => {
+router.get('/categories', async (req: Request, res: Response) => {
     // TODO: find user favorite categories
     const categories = await CategoryModel.getCategoriesByType('normal')
     const defaultCategories = await CategoryModel.getCategoriesByType('special')

--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -15,7 +15,7 @@ router.post('/category/initialize', async (req: Request, res: Response) => {
     res.sendStatus(204)
 })
 
-router.get('/categories', async (req: Request, res: Response) => {
+router.get('/categories', verifyToken, async (req: Request, res: Response) => {
     // TODO: find user favorite categories
     const categories = await CategoryModel.getCategoriesByType('normal')
     const defaultCategories = await CategoryModel.getCategoriesByType('special')
@@ -43,7 +43,7 @@ router.post('/', verifyToken, async (req: Request, res: Response) => {
     res.sendStatus(204)
 })
 
-router.put('/:id', async (req: Request, res: Response) => {
+router.put('/:id', verifyToken, async (req: Request, res: Response) => {
     await EventsModel.updateOne(
         { _id: req.params.id },
         {
@@ -62,7 +62,7 @@ router.put('/:id', async (req: Request, res: Response) => {
     res.sendStatus(204)
 })
 
-router.delete('/:id', async (req: Request, res: Response) => {
+router.delete('/:id', verifyToken, async (req: Request, res: Response) => {
     // TODO : Delete comments
     await EventsModel.deleteOne({ _id: req.params.id })
     res.sendStatus(200)

--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -5,7 +5,7 @@ import mongoose from 'mongoose'
 import { CategoryModel, Events, EventsModel, ReviewsModel, CommentsModel, NotificationModel } from '@/models'
 import { verifyToken } from '@/middlewares/auth'
 import { CategoryCode, NotificationType } from '@fienmee/types'
-import { verifyCommentAuthor } from '@/middlewares/events'
+import { verifyCommentAuthor, verifyEventAuthor } from '@/middlewares/events'
 import { TransactionError } from '@/types/errors/database'
 
 const router: Router = asyncify(express.Router())
@@ -43,7 +43,7 @@ router.post('/', verifyToken, async (req: Request, res: Response) => {
     res.sendStatus(204)
 })
 
-router.put('/:id', verifyToken, async (req: Request, res: Response) => {
+router.put('/:id', verifyToken, verifyEventAuthor, async (req: Request, res: Response) => {
     await EventsModel.updateOne(
         { _id: req.params.id },
         {
@@ -62,7 +62,7 @@ router.put('/:id', verifyToken, async (req: Request, res: Response) => {
     res.sendStatus(204)
 })
 
-router.delete('/:id', verifyToken, async (req: Request, res: Response) => {
+router.delete('/:id', verifyToken, verifyEventAuthor, async (req: Request, res: Response) => {
     // TODO : Delete comments
     await EventsModel.deleteOne({ _id: req.params.id })
     res.sendStatus(200)

--- a/apps/server/src/middlewares/events.ts
+++ b/apps/server/src/middlewares/events.ts
@@ -1,6 +1,18 @@
 import { NextFunction, Request, Response } from 'express'
-import { CommentsModel } from '@/models'
-import { CommentNotFound, UnauthorizedComment } from '@/types/errors/events'
+
+import { CommentsModel, EventsModel } from '@/models'
+import { CommentNotFound, EventNotFound, UnauthorizedComment, UnauthorizedEvent } from '@/types/errors/events'
+
+export const verifyEventAuthor = async (req: Request, res: Response, next: NextFunction) => {
+    const event = await EventsModel.findById(req.params.id).exec()
+    if (!event) {
+        throw new EventNotFound()
+    }
+    if (req.user._id.equals(event.authorId)) {
+        throw new UnauthorizedEvent()
+    }
+    next()
+}
 
 export const verifyCommentAuthor = async (req: Request, res: Response, next: NextFunction) => {
     const comment = await CommentsModel.findOne({ _id: req.params.commentId })

--- a/apps/server/src/types/errors/events.ts
+++ b/apps/server/src/types/errors/events.ts
@@ -15,3 +15,19 @@ export class CommentNotFound extends APIError {
         Error.captureStackTrace(this, CommentNotFound)
     }
 }
+
+export class EventNotFound extends APIError {
+    constructor(cause: Error | string = null) {
+        super(404, 6002, 'invalid event id error', cause)
+        Object.setPrototypeOf(this, EventNotFound.prototype)
+        Error.captureStackTrace(this, EventNotFound)
+    }
+}
+
+export class UnauthorizedEvent extends APIError {
+    constructor(cause: Error | string = null) {
+        super(401, 6003, 'unauthorized event error', cause)
+        Object.setPrototypeOf(this, UnauthorizedEvent.prototype)
+        Error.captureStackTrace(this, UnauthorizedEvent)
+    }
+}


### PR DESCRIPTION
행사 수정, 삭제 API가 verifyToken이 수행하고 있어 생성한 유저가 아니여도 행사를 수정, 삭제할 수 있습니다. 이를 해결하기 위해 로직을 추가합니다. 