### PR TITLE
refactor : refetch query cache after event create, update, and delete

### DIFF
--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -69,7 +69,7 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, handleCategor
                 })
                 toast.success(<span>행사가 성공적으로 수정되었어요.</span>)
                 setEvent(formData)
-                router.push('/events/detail')
+                router.back()
             } else {
                 await registerEvent({
                     body: {
@@ -83,6 +83,7 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, handleCategor
                     },
                 })
                 toast.success(<span>행사가 성공적으로 등록되었어요.</span>)
+                router.back()
             }
         } catch (error) {
             console.error('이벤트 등록 실패:', error)

--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -73,7 +73,6 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, handleCategor
                 toast.success(<span>행사가 성공적으로 수정되었어요.</span>)
                 setEvent(formData)
 
-                await queryClient.invalidateQueries({ queryKey: ['events'] })
                 await queryClient.refetchQueries({ queryKey: ['events'] })
                 router.back()
             } else {
@@ -89,7 +88,6 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, handleCategor
                     },
                 })
 
-                await queryClient.invalidateQueries({ queryKey: ['events'] })
                 await queryClient.refetchQueries({ queryKey: ['events'] })
                 toast.success(<span>행사가 성공적으로 등록되었어요.</span>)
                 router.back()

--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -11,6 +11,7 @@ import InputField from '@/components/events/inputField'
 import SubmitButton from '@/components/events/submitButton'
 import { ArrowIcon } from '@/components/icon'
 import { eventStore } from '@/store'
+import { useQueryClient } from '@tanstack/react-query'
 
 interface EventFormProps {
     selectedCategories: Set<ICategory>
@@ -51,6 +52,7 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, handleCategor
         setFormData(prevState => ({ ...prevState, isAllDay: !prevState.isAllDay }))
     }
 
+    const queryClient = useQueryClient()
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault()
         try {
@@ -67,8 +69,12 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, handleCategor
                     },
                     uri: { _id: initEvent._id },
                 })
+
                 toast.success(<span>행사가 성공적으로 수정되었어요.</span>)
                 setEvent(formData)
+
+                await queryClient.invalidateQueries({ queryKey: ['events'] })
+                await queryClient.refetchQueries({ queryKey: ['events'] })
                 router.back()
             } else {
                 await registerEvent({
@@ -82,6 +88,9 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, handleCategor
                         },
                     },
                 })
+
+                await queryClient.invalidateQueries({ queryKey: ['events'] })
+                await queryClient.refetchQueries({ queryKey: ['events'] })
                 toast.success(<span>행사가 성공적으로 등록되었어요.</span>)
                 router.back()
             }

--- a/apps/web/src/components/events/eventOption.tsx
+++ b/apps/web/src/components/events/eventOption.tsx
@@ -18,6 +18,7 @@ export default function EventOption({ eventId }: { eventId: string }) {
         mutationFn: deleteEventById,
         onSuccess: async () => {
             await queryClient.invalidateQueries({ queryKey: ['events'] })
+            await queryClient.refetchQueries({ queryKey: ['events'] })
             router.back()
             toast.success(<span>행사가 성공적으로 삭제되었어요</span>)
         },

--- a/apps/web/src/components/events/eventOption.tsx
+++ b/apps/web/src/components/events/eventOption.tsx
@@ -18,7 +18,7 @@ export default function EventOption({ eventId }: { eventId: string }) {
         mutationFn: deleteEventById,
         onSuccess: async () => {
             await queryClient.invalidateQueries({ queryKey: ['events'] })
-            router.push('/events/category')
+            router.back()
             toast.success(<span>행사가 성공적으로 삭제되었어요</span>)
         },
         onError: () => {

--- a/apps/web/src/components/events/eventOption.tsx
+++ b/apps/web/src/components/events/eventOption.tsx
@@ -17,7 +17,6 @@ export default function EventOption({ eventId }: { eventId: string }) {
     const deleteMutation = useMutation({
         mutationFn: deleteEventById,
         onSuccess: async () => {
-            await queryClient.invalidateQueries({ queryKey: ['events'] })
             await queryClient.refetchQueries({ queryKey: ['events'] })
             router.back()
             toast.success(<span>행사가 성공적으로 삭제되었어요</span>)


### PR DESCRIPTION
- 라우터 경로를 해당 페이지 뒤로가기로 변경했습니다.
- 캐시 새로고침을 통해 변경된 정보를 바로 반영할 수 있도록 했습니다.