### PR TITLE
fix: issue with observer ref not being rendered in viewport

### DIFF
--- a/apps/web/src/components/events/event.tsx
+++ b/apps/web/src/components/events/event.tsx
@@ -19,13 +19,13 @@ const formatDate = (date: Date) => {
 export default function Event({ event }: Props) {
     if (!event) {
         return (
-            <div className="flex justify-between gap-4 px-4 my-6 animate-pulse">
-                <div className="flex flex-col w-2/3 ps-2 gap-2">
-                    <div className="w-4/5 h-6 bg-[#D9D9D9] my-2" />
-                    <div className="w-3/4 h-3 bg-[#D9D9D9] my-2" />
-                    <div className="w-2/3 h-3 bg-[#D9D9D9] my-2" />
+            <div className="flex justify-between gap-4 mx-4 pb-2 animate-pulse">
+                <div className="flex flex-col min-h-32 w-2/3 ps-2">
+                    <div className="w-full h-6 bg-[#D9D9D9] my-2 rounded" />
+                    <div className="w-5/6 h-3 bg-[#D9D9D9] my-2 rounded" />
+                    <div className="w-2/3 h-3 bg-[#D9D9D9] my-2 rounded" />
                 </div>
-                <div className="flex justify-center items-center w-28 h-28 bg-[#D9D9D9] overflow-hidden me-2" />
+                <div className="flex-1 h-32 bg-[#D9D9D9] overflow-hidden mt-1 me-2 rounded" />
             </div>
         )
     }
@@ -41,16 +41,16 @@ export default function Event({ event }: Props) {
         <Link
             href={`/events/detail`}
             onClick={onClick}
-            className="flex hover:bg-gray-100 transition duration-300 justify-between items-start gap-4 px-4"
+            className="flex hover:bg-gray-100 transition duration-300 justify-between items-start gap-4 mx-4 pb-2"
         >
-            <div className="flex flex-col w-2/3 ps-2 pt-2 gap-2">
-                <div className="text-xl font-semibold">{event.name}</div>
-                <div className="text-lg text-gray-600">{`${formatDate(event.startDate)}~${formatDate(event.endDate)}`}</div>
-                <div className="text-lg text-gray-600">{event.address}</div>
+            <div className="flex flex-col min-h-32 w-2/3 ps-2">
+                <div className="text-lg font-semibold">{event.name}</div>
+                <div className="text-base text-gray-600">{`${formatDate(event.startDate)}~${formatDate(event.endDate)}`}</div>
+                <div className="text-base text-gray-600">{event.address}</div>
             </div>
-            <div className="flex justify-center items-center w-28 bg-[#D9D9D9] overflow-hidden me-2">
+            <div className="flex-1 bg-[#D9D9D9] overflow-hidden mt-1 me-2 rounded">
                 {/*TODO: change image tag*/}
-                <img src={event.photo[0]} alt="대표 사진" className="w-full h-full object-cover" />
+                <img src={event.photo[0]} alt="대표 사진" className="w-full h-full object-cover object-top" />
             </div>
         </Link>
     )

--- a/apps/web/src/components/events/eventList.tsx
+++ b/apps/web/src/components/events/eventList.tsx
@@ -52,8 +52,8 @@ export function EventList({ category }: { category: string }) {
     }
 
     return (
-        <div className="h-full w-full">
-            <div className="flex flex-col h-full w-full px-2 mt-4 gap-6">
+        <div className="h-full w-full mb-4">
+            <div className="flex flex-col h-full w-full mt-4 gap-2">
                 {data && data.pages.map(events => events.events.map(event => <Event event={event} key={event._id} />))}
             </div>
             {isFetchingNextPage ? <Event event={undefined} /> : <div ref={ref} />}


### PR DESCRIPTION
행사 목록을 카테고리를 통해 조회할 때 각 행사 컴포넌트 요소들에서 이미지의 크기가 부모 요소를 넘치는 문제가 있었습니다. 이로 인해 무한스크롤에 필요한 ref 객체가 화면에 보이지 않아 무한 스크롤이 특정 시점에서 동작하지 않는 문제가 있었습니다. 이를 해결하기 위해 컴포넌트의 UI를 조정합니다. 