### PR TITLE
fix: prevent incorrect navigation when clicking category during iniaital load

### DIFF
--- a/apps/web/src/app/(navigation)/events/loading.tsx
+++ b/apps/web/src/app/(navigation)/events/loading.tsx
@@ -5,15 +5,13 @@ export default function Loading() {
     return (
         <div className="grid justify-items-center px-8 mt-6">
             <div className="grid border-b gap-4 w-full py-2 border-gray-300">
-                <CategoryItem category={{ _id: '', ...fixedCategory[CategoryCode.MYEVENT] }} isFavorites={false} />
-                <CategoryItem category={{ _id: '', ...fixedCategory[CategoryCode.HOTEVENT] }} isFavorites={false} />
+                <CategoryItem category={{ _id: CategoryCode.MYEVENT, title: fixedCategory[CategoryCode.MYEVENT].title }} isFavorites={false} />
+                <CategoryItem category={{ _id: CategoryCode.HOTEVENT, title: fixedCategory[CategoryCode.HOTEVENT].title }} isFavorites={false} />
             </div>
             <div className="grid border-b gap-4 w-full py-2 border-gray-300">
-                <CategoryItemSkeleton />
-                <CategoryItemSkeleton />
-                <CategoryItemSkeleton />
-                <CategoryItemSkeleton />
-                <CategoryItemSkeleton />
+                {Array.from({ length: 10 }).map((_, index) => (
+                    <CategoryItemSkeleton key={index} />
+                ))}
             </div>
         </div>
     )


### PR DESCRIPTION
FE에서 /events 페이지에 최초 접근 시 로딩화면에서 보여지는 "내가 등록한 행사", "인기 행사" 카테고리를 선택하는 경우 잘못된 접근이 발생하는 이슈를 해결합니다. 또한, 스켈레톤을 추가하여 자연스럽게 카테고리가 로드되는 것처럼 보이게 수정합니다. 