### PR TITLE
refactor: layout structure and improve UI/UX

### DIFF
--- a/apps/web/src/app/(backButton)/layout.tsx
+++ b/apps/web/src/app/(backButton)/layout.tsx
@@ -1,11 +1,7 @@
 import React from 'react'
 import { PageTitleHeader } from '@/components/header'
+import { BaseLayout } from '@/components/layout/BaseLayout'
 
 export default function BackButtonLayout({ children }: { children: React.ReactNode }) {
-    return (
-        <div className="flex flex-col w-full h-dvh">
-            <PageTitleHeader />
-            <div className="w-full overflow-y-scroll">{children}</div>
-        </div>
-    )
+    return <BaseLayout header={<PageTitleHeader />}>{children}</BaseLayout>
 }

--- a/apps/web/src/app/(navigation)/layout.tsx
+++ b/apps/web/src/app/(navigation)/layout.tsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import { LogoHeader } from '@/components/header'
 import { Navigation } from '@/components/navigation'
+import { BaseLayout } from '@/components/layout/BaseLayout'
 
 export default function NavigationLayout({ children }: { children: React.ReactNode }) {
     return (
-        <div className="flex flex-col w-full h-dvh">
-            <LogoHeader />
-            <div className="w-full h-full overflow-y-scroll">{children}</div>
-            <Navigation />
-        </div>
+        <BaseLayout header={<LogoHeader />} footer={<Navigation />}>
+            {children}
+        </BaseLayout>
     )
 }

--- a/apps/web/src/components/header/logo.tsx
+++ b/apps/web/src/components/header/logo.tsx
@@ -3,7 +3,7 @@ import { NotificationIcon, TextLogo } from '@/components/icon'
 
 export function LogoHeader() {
     return (
-        <div className="flex flex-row w-full h-[6.25rem] items-center justify-between bg-white pt-10 p-2">
+        <div className="flex flex-row w-full h-[5rem] items-center justify-between bg-white p-2">
             <div className="ps-4">
                 <TextLogo width="9.375rem" height="3rem" />
             </div>

--- a/apps/web/src/components/header/pageTitle.tsx
+++ b/apps/web/src/components/header/pageTitle.tsx
@@ -20,9 +20,9 @@ export function PageTitleHeader() {
     }
 
     return (
-        <div className="flex flex-row items-center w-full h-[6.25rem] bg-white pt-4 p-2">
+        <div className="flex flex-row w-full h-[5rem] items-center bg-white p-2">
             <button className="absolute z-1 ps-4" onClick={onClick}>
-                <BackButtonIcon width="1.75rem" height="1.75rem" />
+                <BackButtonIcon width="1.5rem" height="1.5rem" />
             </button>
             <span className="text-3xl text-center font-semibold w-full">{title}</span>
         </div>

--- a/apps/web/src/components/layout/BaseLayout.tsx
+++ b/apps/web/src/components/layout/BaseLayout.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+
+interface BaseLayoutProps {
+    header: React.ReactNode
+    children: React.ReactNode
+    footer?: React.ReactNode
+}
+
+export function BaseLayout({ header, children, footer }: BaseLayoutProps) {
+    return (
+        <div className="flex flex-col w-full h-dvh">
+            <div className="shrink-0">{header}</div>
+            <main className="w-full h-full overflow-y-scroll">{children}</main>
+            <div className="shrink-0">{footer}</div>
+        </div>
+    )
+}

--- a/apps/web/src/components/navigation/navigation.tsx
+++ b/apps/web/src/components/navigation/navigation.tsx
@@ -29,7 +29,7 @@ export function Navigation() {
     return (
         <div className="flex flex-col items-center justify-center w-full">
             <div
-                className={`fixed grid grid-cols-2 w-48 h-48 z-30 bg-white rounded-full shadow-[0_-1px_4px_rgba(0,0,0,0.25)] transition-all duration-700 pb-16 ${isVisible ? 'opacity-100 -translate-y-[4rem]' : 'opacity-0 translate-y-10'}`}
+                className={`fixed grid grid-cols-2 w-48 h-48 z-30 bg-white rounded-full shadow-[0_-1px_4px_rgba(0,0,0,0.25)] transition-all duration-700 pb-16 ${isVisible ? 'opacity-100 -translate-y-[3.5rem]' : 'opacity-0 translate-y-10'}`}
             >
                 <div className="absolute top-5 h-1/3 left-1/2 w-[1px] bg-gray-300" />
                 <NavigationItem
@@ -46,26 +46,26 @@ export function Navigation() {
                     <AddScheduleButtonIcon width="2rem" height="2rem" />
                 </NavigationItem>
             </div>
-            <div className="grid h-28 w-full grid-cols-5 mx-auto font-medium bg-white shadow-[0_-1px_4px_rgba(0,0,0,0.25)] z-40">
+            <div className="grid h-[6.25rem] w-full grid-cols-5 mx-auto font-medium bg-white shadow-[0_-1px_4px_rgba(0,0,0,0.25)] z-40">
                 <NavigationItem uri={'/'} text={'홈'} isClicked={pathname === '/'}>
-                    <HomeNavigationIcon isClicked={pathname === '/'} width="3rem" height="3rem" />
+                    <HomeNavigationIcon isClicked={pathname === '/'} width="2.25rem" height="2.25rem" />
                 </NavigationItem>
                 <NavigationItem uri={'/schedules'} text={'캘린더'} isClicked={pathname === '/schedules'}>
-                    <CalenderNavigationIcon isClicked={pathname === '/schedules'} width="3rem" height="3rem" />
+                    <CalenderNavigationIcon isClicked={pathname === '/schedules'} width="2.25rem" height="2.25rem" />
                 </NavigationItem>
                 <div className="inline-flex flex-col items-center justify-center p-2">
                     <button
-                        className="w-20 h-20 inline-flex flex-col items-center justify-center bg-transparent shadow-[0_4px_4px_rgba(0,0,0,0.25)] rounded-full"
+                        className="w-16 h-16 inline-flex flex-col items-center justify-center bg-transparent shadow-[0_4px_4px_rgba(0,0,0,0.25)] rounded-full"
                         onClick={() => setIsVisible(!isVisible)}
                     >
-                        <NavigationPlusIcon width="1.375rem" height="1.375rem" />
+                        <NavigationPlusIcon width="1.25rem" height="1.25rem" />
                     </button>
                 </div>
                 <NavigationItem uri={'/events'} text={'카테고리'} isClicked={pathname === '/events'}>
-                    <CategoryNavigationIcon isClicked={pathname === '/events'} width="3rem" height="3rem" />
+                    <CategoryNavigationIcon isClicked={pathname === '/events'} width="2.25rem" height="2.25rem" />
                 </NavigationItem>
                 <NavigationItem uri={'/setting'} text={'마이페이지'} isClicked={pathname === '/setting'}>
-                    <MyInfoNavigationIcon isClicked={pathname === '/setting'} width="3rem" height="3rem" />
+                    <MyInfoNavigationIcon isClicked={pathname === '/setting'} width="2.25rem" height="2.25rem" />
                 </NavigationItem>
             </div>
         </div>


### PR DESCRIPTION
현재 레이아웃에서 메인 콘텐츠 요소를 보여주는 화면에서 헤더의 크기가 순간적으로 변경되는 문제, 헤더와 네비게이션 바가 너무 많은 영역을 차지하는 문제를 해결하기 위해 다음과 같은 작업을 수행합니다. 

- (backButton)과 (navigation) 부분의 레이아웃의 요소의 영역을 공통으로 관리하기 위해 `BaseLayout` 컴포넌트를 생성합니다.
- 두 종류의 헤더(`logo.tsx`, `pageTitle.tsx`)의 높이를 5rem으로 줄입니다.
- `navigation`의 높이를 7rem에서 6.25rem으로 변경하면서 아이콘의 크기를 줄이고, 추가 버튼이 올라오는 높이도 3.5rem으로 조정합니다.

변경 전과 후 사진은 다음과 같습니다.

### 변경 전
<img src="https://github.com/user-attachments/assets/d1dbf718-a2b7-413b-a71a-4850886ff834" width="300" />
<img src="https://github.com/user-attachments/assets/af160dcc-1c2a-4188-b4cc-0d8e2613c270" width="300" />

### 변경 후
<img src="https://github.com/user-attachments/assets/66a2be7e-3f5b-4c12-a063-57a742e6b753" width="300" />
<img src="https://github.com/user-attachments/assets/2ad113a9-f8c4-4ec8-b4bc-44eac2d23c1f" width="300" />
