### PR TITLE
refactor: image handling to use s3 key instead of presigned URLs

### DIFF
--- a/apps/web/src/app/(backButton)/events/register/page.tsx
+++ b/apps/web/src/app/(backButton)/events/register/page.tsx
@@ -3,32 +3,16 @@
 import { useState } from 'react'
 
 import { ICategory } from '@fienmee/types'
-import PhotoUploader from '@/components/events/photoUploader'
 import EventForm from '@/components/events/eventForm'
 import { eventStore } from '@/store'
 
 export default function RegisterPage() {
     const [selectedCategories, setSelectedCategories] = useState<Set<ICategory>>(new Set())
-    const { event, setEvent } = eventStore()
-
-    const handleAddPhoto = (photoUrls: string[]) => {
-        setEvent({ ...event, photo: [...event.photo, ...photoUrls] })
-    }
-
-    const handleRemovePhoto = (index: number) => {
-        setEvent({ ...event, photo: event.photo.filter((_, i) => i !== index) })
-    }
+    const { event } = eventStore()
 
     return (
         <div className="grid items-center justify-items-center min-h-screen">
-            <PhotoUploader photos={event.photo ?? []} onAddPhoto={handleAddPhoto} onRemovePhoto={handleRemovePhoto} />
-            <EventForm
-                selectedCategories={selectedCategories}
-                handleCategories={setSelectedCategories}
-                photos={event.photo ?? []}
-                initEvent={event}
-                isRegister={true}
-            />
+            <EventForm selectedCategories={selectedCategories} handleCategories={setSelectedCategories} initEvent={event} isRegister={true} />
         </div>
     )
 }

--- a/apps/web/src/app/(backButton)/events/update/page.tsx
+++ b/apps/web/src/app/(backButton)/events/update/page.tsx
@@ -3,7 +3,6 @@
 import { Suspense, useState } from 'react'
 
 import { ICategory } from '@fienmee/types'
-import PhotoUploader from '@/components/events/photoUploader'
 import EventForm from '@/components/events/eventForm'
 import { eventStore } from '@/store'
 
@@ -17,27 +16,11 @@ export default function EventUpdate() {
 
 function UpdatePageContent() {
     const { event } = eventStore()
-    const [photo, setPhoto] = useState<string[]>(event.photo)
     const [selectedCategories, setSelectedCategories] = useState<Set<ICategory>>(new Set(event.category ?? []))
-
-    const handleAddPhoto = (photoUrls: string[]) => {
-        setPhoto([...photo, ...photoUrls])
-    }
-
-    const handleRemovePhoto = (index: number) => {
-        setPhoto(photo.filter((_, i) => i !== index))
-    }
 
     return (
         <div className="grid items-center justify-items-center min-h-screen">
-            <PhotoUploader photos={photo} onAddPhoto={handleAddPhoto} onRemovePhoto={handleRemovePhoto} />
-            <EventForm
-                selectedCategories={selectedCategories}
-                handleCategories={setSelectedCategories}
-                photos={photo}
-                initEvent={event}
-                isRegister={false}
-            />
+            <EventForm selectedCategories={selectedCategories} handleCategories={setSelectedCategories} initEvent={event} isRegister={false} />
         </div>
     )
 }

--- a/apps/web/src/components/events/EventImage.tsx
+++ b/apps/web/src/components/events/EventImage.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react'
+import { useImageLoader } from '@/hooks/s3/useImageLoader'
+import { ClipLoader } from 'react-spinners'
+
+interface EventImageProps {
+    s3Key: string
+    alt: string
+    className?: string
+}
+
+const EventImage: React.FC<EventImageProps> = ({ s3Key, alt, className }) => {
+    const { imageUrl, isLoading } = useImageLoader(s3Key)
+    const [hasError, setHasError] = useState(false)
+
+    if (isLoading) {
+        return (
+            <div className={`flex items-center justify-center ${className || ''}`}>
+                <ClipLoader color="#FF9575" size={20} />
+            </div>
+        )
+    }
+
+    if (hasError || !imageUrl) {
+        return <div className={`flex items-center justify-center bg-gray-200 text-gray-500 ${className || ''}`}>이미지 로드 실패</div>
+    }
+
+    return <img src={imageUrl} alt={alt} className={className} onError={() => setHasError(true)} />
+}
+
+export default EventImage

--- a/apps/web/src/components/events/event.tsx
+++ b/apps/web/src/components/events/event.tsx
@@ -4,6 +4,7 @@ import { IEvent } from '@fienmee/types'
 
 import { eventStore } from '@/store/event'
 import { titleStore } from '@/store'
+import EventImage from '@/components/events/EventImage'
 
 interface Props {
     event: IEvent | undefined
@@ -41,9 +42,12 @@ export default function Event({ event }: Props) {
                 <div className="text-base text-gray-600">{`${format(event.startDate, 'yyyy-MM-dd')}~${format(event.endDate, 'yyyy-MM-dd')}`}</div>
                 <div className="text-base text-gray-600">{event.address}</div>
             </div>
-            <div className="flex-1 bg-[#D9D9D9] overflow-hidden mt-1 me-2 rounded">
-                {/*TODO: change image tag*/}
-                <img src={event.photo[0]} alt="대표 사진" className="w-full h-full object-cover object-top" />
+            <div className="flex-1 h-36 bg-[#D9D9D9] overflow-hidden mt-1 me-2 rounded">
+                {event.photo && event.photo.length > 0 ? (
+                    <EventImage s3Key={event.photo[0]} alt="대표 사진" className="w-full h-full object-cover object-top" />
+                ) : (
+                    <div className="w-full h-full bg-gray-300 flex items-center justify-center text-gray-500">이미지 없음</div>
+                )}
             </div>
         </Link>
     )

--- a/apps/web/src/components/events/eventPhoto.tsx
+++ b/apps/web/src/components/events/eventPhoto.tsx
@@ -3,6 +3,8 @@ import { Pagination } from 'swiper/modules'
 import 'swiper/css'
 import 'swiper/css/pagination'
 
+import EventImage from '@/components/events/EventImage'
+
 interface Props {
     photo: string[]
     name: string
@@ -11,10 +13,10 @@ interface Props {
 export default function EventPhoto({ photo, name }: Props) {
     return (
         <Swiper modules={[Pagination]} pagination={{ clickable: true }} className="w-full h-64">
-            {photo.map((photoUrl, index) => (
+            {photo.map((s3Key, index) => (
                 <SwiperSlide key={index}>
                     <div className="w-full h-full">
-                        <img src={photoUrl} alt={`${name} ${index + 1}`} className="w-full h-full object-contain" />
+                        <EventImage s3Key={s3Key} alt={`${name} ${index + 1}`} className="w-full h-full object-contain" />
                     </div>
                 </SwiperSlide>
             ))}

--- a/apps/web/src/components/review/ReviewImage.tsx
+++ b/apps/web/src/components/review/ReviewImage.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { useImageLoader } from '@/hooks/s3'
+
+interface Props {
+    s3Key: string
+}
+
+export default function ReviewImage({ s3Key }: Props) {
+    const { imageUrl, isLoading, error } = useImageLoader(s3Key)
+
+    if (isLoading) {
+        return <div className="w-[7.5rem] h-[7.5rem] bg-[#D9D9D9] rounded animate-pulse" />
+    }
+
+    if (error) {
+        return (
+            <div className="w-[7.5rem] h-[7.5rem] bg-gray-200 rounded flex items-center justify-center text-xs text-gray-500">이미지 로드 실패</div>
+        )
+    }
+
+    return <img className="w-[7.5rem] h-[7.5rem] object-cover object-center" alt={`review img`} src={imageUrl} />
+}

--- a/apps/web/src/components/review/review.tsx
+++ b/apps/web/src/components/review/review.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns'
 
 import { IReview } from '@fienmee/types'
 import { StarIcon } from '@/components/icon'
+import ReviewImage from '@/components/review/ReviewImage'
 
 interface Props {
     review: IReview | undefined
@@ -49,13 +50,8 @@ export default function Review({ review }: Props) {
             {review.photo.length !== 0 && (
                 <div className="overflow-x-auto scroll-smooth snap-x px-2.5">
                     <div className="flex flex-row w-max gap-[0.3125rem]">
-                        {review.photo.map(img => (
-                            <img
-                                className="w-[7.5rem] h-[7.5rem] object-cover object-center"
-                                key={`${review._id}-reviewImg-${img}`}
-                                alt={`review img`}
-                                src={img}
-                            />
+                        {review.photo.map((s3Key, index) => (
+                            <ReviewImage key={`${review._id}-reviewImg-${index}`} s3Key={s3Key} />
                         ))}
                     </div>
                 </div>

--- a/apps/web/src/hooks/s3/index.ts
+++ b/apps/web/src/hooks/s3/index.ts
@@ -1,0 +1,2 @@
+export * from './useS3Upload'
+export * from './useImageLoader'

--- a/apps/web/src/hooks/s3/useImageLoader.ts
+++ b/apps/web/src/hooks/s3/useImageLoader.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect } from 'react'
+import { getViewUrl } from '@/api/s3'
+
+export const useImageLoader = (s3KeyOrUrl: string) => {
+    const [imageUrl, setImageUrl] = useState<string>('')
+    const [isLoading, setIsLoading] = useState<boolean>(true)
+    const [error, setError] = useState<string | null>(null)
+
+    useEffect(() => {
+        let isMounted = true
+
+        const loadImage = async () => {
+            if (!s3KeyOrUrl) {
+                if (isMounted) {
+                    setImageUrl('')
+                    setIsLoading(false)
+                    setError(null)
+                }
+                return
+            }
+
+            setIsLoading(true)
+            setError(null)
+
+            if (s3KeyOrUrl.startsWith('http://') || s3KeyOrUrl.startsWith('https://')) {
+                if (isMounted) {
+                    setImageUrl(s3KeyOrUrl)
+                    setIsLoading(false)
+                }
+            } else {
+                try {
+                    const { presignedUrl } = await getViewUrl(s3KeyOrUrl)
+                    if (isMounted) {
+                        setImageUrl(presignedUrl)
+                    }
+                } catch (err) {
+                    console.error('Error fetching presigned URL:', err)
+                    if (isMounted) {
+                        setError('Failed to load image from S3 key')
+                        setImageUrl('')
+                    }
+                } finally {
+                    if (isMounted) {
+                        setIsLoading(false)
+                    }
+                }
+            }
+        }
+
+        loadImage()
+
+        return () => {
+            isMounted = false
+        }
+    }, [s3KeyOrUrl])
+
+    return { imageUrl, isLoading, error }
+}

--- a/apps/web/src/hooks/s3/useS3Upload.ts
+++ b/apps/web/src/hooks/s3/useS3Upload.ts
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { toast } from 'react-toastify'
+import { getUploadUrl, getViewUrl, uploadToS3 } from '@/api/s3'
+
+export const useS3Upload = () => {
+    const [isUploading, setIsUploading] = useState(false)
+
+    const uploadFile = async (file: File): Promise<{ key: string; viewUrl: string } | null> => {
+        try {
+            const { presignedUrl: uploadUrl } = await getUploadUrl({
+                fileName: file.name,
+                fileType: file.type,
+            })
+            const key = uploadUrl.split('?')[0].split('/').pop()!
+            await uploadToS3(uploadUrl, file)
+
+            const { presignedUrl: viewUrl } = await getViewUrl(key)
+            return { key, viewUrl }
+        } catch (error) {
+            console.error(error)
+            return null
+        }
+    }
+
+    const handleImageUpload = async (files: FileList | null, onSuccess: (results: Array<{ key: string; viewUrl: string }>) => void) => {
+        if (!files || files.length === 0) return
+
+        setIsUploading(true)
+
+        try {
+            const results = await Promise.all(Array.from(files).map(uploadFile))
+            const succeeded = results.filter((result): result is { key: string; viewUrl: string } => result !== null)
+            const failedCount = results.filter(result => result === null).length
+
+            if (succeeded.length > 0) {
+                onSuccess(succeeded)
+            }
+
+            if (failedCount > 0) {
+                toast.error(`${failedCount}개의 사진 업로드를 실패했어요. 다시 한번 시도해주세요.`)
+            }
+        } catch (error) {
+            console.error(error)
+            toast.error('사진 업로드 중 예상치 못한 오류가 발생했어요. 다시 시도해주세요.')
+        } finally {
+            setIsUploading(false)
+        }
+    }
+
+    return { isUploading, handleImageUpload }
+}


### PR DESCRIPTION
리뷰 등록, 일정 등록 및 일정 수정 시 이미지 업로드에 S3 Presigned URL을 사용하고 있었습니다. 그러나 Presigned URL의 만료로 인해 시간이 지나면 이미지 링크가 깨지는 문제가 발생했습니다. 이러한 이슈를 해결하기 위해 이미지 저장 방식을 다음과 같이 수정하였습니다.

주요 변경사항은 다음과 같습니다:
 - s3 key 기반관리: 사용자가 업로드한 이미지는 이제 Presigned URL이 아닌 S3 Key 값으로 관리됩니다.
 - `useS3Upload` 훅 도입: s3 이미지를 업로드하고 해당 s3 키를 반환하는 로직을 캡슐화합니다.
 - `useIamgeLoader` 훅 도입: S3 Key를 기반으로 필요한 시점에 이미지 URL을 동적으로 로드합니다.
 -  새로운 이미지 표시 컴포넌트 도입: `EventImage`, `ReviewImage` 컴포넌트를 통해 이미지 로드 및 오류, 로딩 처리를 합니다.


추가적으로, 이미지 로딩 성능 향상과 비용 효율성을 위해 향후 CloudFront 도입을 고려할 수 있습니다. 이를 통해 Presigned URL을 지속적으로 생성하는 비용을 제거하고, 이미지 접근 속도도 개선할 수 있습니다.