### PR TITLE
fix: return pagination data for HOTEVENT category requests

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -295,7 +295,17 @@ router.get(`/category/${CategoryCode.HOTEVENT}`, verifyToken, async (req: Reques
         isLiked: event['likes']?.includes(req.user._id),
     }))
 
-    res.status(200).json({ events: events })
+    res.status(200).json({
+        events: events,
+        page: {
+            totalDocs: result.totalDocs,
+            totalPages: result.totalPages,
+            hasNextPage: result.hasNextPage,
+            hasPrevPage: result.hasPrevPage,
+            page: result.page,
+            limit: result.limit,
+        },
+    })
 })
 
 router.get('/category/:category', verifyToken, async (req: Request, res: Response) => {
@@ -305,7 +315,6 @@ router.get('/category/:category', verifyToken, async (req: Request, res: Respons
     if (req.params.category === CategoryCode.MYEVENT) {
         result = await EventsModel.findByAuthor(req.user._id, options)
     } else {
-        // TODO: add get hottest events
         result = await EventsModel.findByCategory([req.params.category], options)
     }
     const events = result.docs.map(event => ({

--- a/apps/web/src/app/(backButton)/events/category/page.tsx
+++ b/apps/web/src/app/(backButton)/events/category/page.tsx
@@ -16,7 +16,7 @@ export default function Page() {
     return (
         <div className="items-center justify-items-center bg-inherit">
             <div className="w-full h-full bg-inherit">
-                <EventList category={category._id} />
+                <EventList category={category._id.toString()} />
             </div>
         </div>
     )


### PR DESCRIPTION
카테고리 페이지에서 인기행사 카테고리에 접근할 때 pagination data를 리턴하고 있지 않아 페이지 접근이 되지 않는 문제를 해결하기 위해 paginatio data를 리턴합니다. 

특정 카테고리 _id 에 요청을 보낼 때 (HOTEVENT 등)에서 요청 자체에서 오류가 발생하는 문제가 생겨 .toString() 함수를 추가합니다. 