### PR TITLE
feat: automatically delete withdrawn member information

### DIFF
--- a/apps/server/src/models/user.ts
+++ b/apps/server/src/models/user.ts
@@ -66,7 +66,7 @@ export class User extends defaultClasses.TimeStamps implements IUser {
         return await this.findByIdAndUpdate(userId, { $pull: { interests: categoryId } }, { new: true }).exec()
     }
 
-    public static async removeDeletedUserInfo(this: ReturnModelType<typeof User>) {
+    public static async removeDeletedUserInfo(this: ReturnModelType<typeof User>): Promise<number> {
         const refDate = new Date()
         refDate.setMonth(refDate.getMonth() - 1)
 

--- a/apps/server/src/models/user.ts
+++ b/apps/server/src/models/user.ts
@@ -65,6 +65,18 @@ export class User extends defaultClasses.TimeStamps implements IUser {
     public static async removeInterest(this: ReturnModelType<typeof User>, userId: mongoose.Types.ObjectId, categoryId: string): Promise<User> {
         return await this.findByIdAndUpdate(userId, { $pull: { interests: categoryId } }, { new: true }).exec()
     }
+
+    public static async removeDeletedUserInfo(this: ReturnModelType<typeof User>) {
+        const refDate = new Date()
+        refDate.setMonth(refDate.getMonth() - 1)
+
+        const result = await this.deleteMany({
+            isDeleted: true,
+            updatedAt: { $lt: refDate },
+        }).exec()
+
+        return result.deletedCount
+    }
 }
 
 export const UserModel = getModelForClass(User)

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -18,7 +18,7 @@ export default class DateBatchScheduler {
         schedule.scheduleJob('0 3 * * *', async () => {
             try {
                 const deletedUsers = await deleteOldDeletedUsers()
-                logger.info('Scheduler job finished for old deleted user data: ', deletedUsers)
+                logger.info(`Scheduler job finished for old deleted user data: ${deletedUsers}`)
             } catch (error) {
                 logger.error(`Delete User data Scheduler failed.`, { error: error })
             }

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -2,6 +2,7 @@ import schedule from 'node-schedule'
 
 import { fetchAndSaveSeoulData } from '@/services/seoul/databatch'
 import { logger } from '@/utils/logger'
+import { deleteOldDeletedUsers } from '@/services/user'
 
 export default class DateBatchScheduler {
     public run() {
@@ -11,6 +12,15 @@ export default class DateBatchScheduler {
                 await fetchAndSaveSeoulData()
             } catch (error) {
                 logger.error(`Seoul Data Scheduler failed.`, { error: error })
+            }
+        })
+
+        schedule.scheduleJob('0 3 * * *', async () => {
+            try {
+                const deletedUsers = await deleteOldDeletedUsers()
+                logger.info('Scheduler job finished for old deleted user data: ', deletedUsers)
+            } catch (error) {
+                logger.error(`Delete User data Scheduler failed.`, { error: error })
             }
         })
     }

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -17,8 +17,8 @@ export default class DateBatchScheduler {
 
         schedule.scheduleJob('0 3 * * *', async () => {
             try {
-                const deletedUsers = await deleteOldDeletedUsers()
-                logger.info(`Scheduler job finished for old deleted user data: ${deletedUsers}`)
+                const deletedUsersCount = await deleteOldDeletedUsers()
+                logger.info(`Scheduler job finished for old deleted user data: ${deletedUsersCount}`)
             } catch (error) {
                 logger.error(`Delete User data Scheduler failed.`, { error: error })
             }

--- a/apps/server/src/services/user.ts
+++ b/apps/server/src/services/user.ts
@@ -11,3 +11,7 @@ export async function registerUser(oauthUser: IUser): Promise<User> {
     }
     return user
 }
+
+export async function deleteOldDeletedUsers(): Promise<number> {
+    return await UserModel.removeDeletedUserInfo()
+}

--- a/apps/server/src/services/user.ts
+++ b/apps/server/src/services/user.ts
@@ -13,5 +13,5 @@ export async function registerUser(oauthUser: IUser): Promise<User> {
 }
 
 export async function deleteOldDeletedUsers(): Promise<number> {
-    return await UserModel.removeDeletedUserInfo()
+    return UserModel.removeDeletedUserInfo()
 }


### PR DESCRIPTION
회원 탈퇴한 유저의 정보를 자동으로 삭제하는 기능을 개발하였습니다.
- 자동으로 유저 모델에서 데이터를 삭제하는 스케쥴러 함수 추가
- 현재는 updatedAt이 1달 지났고 isDeleted가 true인 유저의 데이터를 삭제하고 있습니다.

TODO
- 회원 탈퇴 API에서 회원의 닉네임을 변경하는 작업이 필요합니다.