### PR TITLE
feat: improve all-day event display and sorting logic

### DIFF
--- a/apps/server/src/models/schedule.ts
+++ b/apps/server/src/models/schedule.ts
@@ -65,7 +65,22 @@ export class Schedule extends defaultClasses.TimeStamps {
             limit: number
         },
     ) {
-        return await this.paginate({ authorId: userId, startDate: { $lt: filterOption.to }, endDate: { $gt: filterOption.from } }, options)
+        return await this.paginate(
+            {
+                authorId: userId,
+                startDate: { $lt: filterOption.to },
+                endDate: { $gt: filterOption.from },
+            },
+            {
+                page: options.page,
+                limit: options.limit,
+                sort: {
+                    isAllDay: -1,
+                    startDate: 1,
+                    endDate: 1,
+                },
+            },
+        )
     }
 
     public static async findDailyCountByUserId(

--- a/apps/web/src/components/schedules/scheduleDetail.tsx
+++ b/apps/web/src/components/schedules/scheduleDetail.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from 'react'
 import Link from 'next/link'
 import { format } from 'date-fns'
+import { ko } from 'date-fns/locale'
 
 import { IScheduleItem } from '@fienmee/types'
 import { getEventDetail } from '@/api/event'
@@ -60,7 +61,7 @@ export default function ScheduleDetailModal({ isOpen, onClose, schedule, setModa
 
     const formatTime = (date: Date) => {
         const newDate = new Date(date)
-        return format(newDate, 'MM.dd HH:mm a')
+        return format(newDate, 'MM.dd a h:mm', { locale: ko })
     }
     const timeRange = schedule.isAllDay ? '하루 종일' : `${formatTime(schedule.startDate)} - ${formatTime(schedule.endDate)}`
 

--- a/apps/web/src/components/schedules/scheduleItem.tsx
+++ b/apps/web/src/components/schedules/scheduleItem.tsx
@@ -11,7 +11,7 @@ interface ScheduleProp {
 
 export default function ScheduleItem({ startDate, endDate, title, isAllDay, onClick }: ScheduleProp) {
     const formatTime = (date: Date) => {
-        return format(date, 'MM.dd a h:mm', { locale: ko })
+        return format(new Date(date), 'MM.dd a h:mm', { locale: ko })
     }
     return (
         <div className="flex flex-col" onClick={onClick}>

--- a/apps/web/src/components/schedules/scheduleItem.tsx
+++ b/apps/web/src/components/schedules/scheduleItem.tsx
@@ -1,20 +1,22 @@
 import { format } from 'date-fns'
+import { ko } from 'date-fns/locale'
 
 interface ScheduleProp {
     startDate: Date
     endDate: Date
     title: string
+    isAllDay: boolean
     onClick?: () => void
 }
 
-export default function ScheduleItem({ startDate, endDate, title, onClick }: ScheduleProp) {
+export default function ScheduleItem({ startDate, endDate, title, isAllDay, onClick }: ScheduleProp) {
     const formatTime = (date: Date) => {
-        return format(date, 'MM.dd HH:mm a')
+        return format(date, 'MM.dd a h:mm', { locale: ko })
     }
     return (
         <div className="flex flex-col" onClick={onClick}>
             <div className="text-lg text-[#1B1B1B] p-4 pb-1">{title}</div>
-            <div className="text-base text-[#B8BABB] px-4 pb-1">{`${formatTime(startDate)} - ${formatTime(endDate)}`}</div>
+            <div className="text-base text-[#B8BABB] px-4 pb-1">{isAllDay ? '하루 종일' : `${formatTime(startDate)} - ${formatTime(endDate)}`}</div>
         </div>
     )
 }

--- a/apps/web/src/components/schedules/scheduleList.tsx
+++ b/apps/web/src/components/schedules/scheduleList.tsx
@@ -111,6 +111,7 @@ export default function ScheduleList({ date }: Prop) {
                                 key={schedule._id}
                                 title={schedule.name}
                                 startDate={schedule.startDate}
+                                isAllDay={schedule.isAllDay}
                                 endDate={schedule.endDate}
                                 onClick={() => handleClick(i, j)}
                             />


### PR DESCRIPTION
- 행사 조회 API에 기본 정렬 추가 (isAllDay 우선, startDate/ endDate 오름차순)
- 기존 하루종일 일정 표시 방식을 '하루 종일' 라벨로 변경하여 가독성 향상