### PR TITLE
feat: add deferred member nickname processing

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -97,7 +97,6 @@ router.get('/:id', verifyToken, async (req: Request, res: Response) => {
 router.post('/:id/comments', verifyToken, async (req: Request, res: Response) => {
     const comment = await CommentsModel.create({
         userId: req.user._id,
-        nickname: req.user.nickname,
         eventId: req.params.id,
         comment: req.body.comment,
     })
@@ -123,8 +122,8 @@ router.get('/:id/comments', verifyToken, async (req: Request, res: Response) => 
     }
     const result = await CommentsModel.findByEventId(req.params.id, options)
     const modifiedDocs = result.docs.map(comment => ({
-        ...comment.toJSON(),
-        isAuthor: comment.get('userId')?.equals(req.user._id),
+        ...comment.toObject(),
+        isAuthor: comment.get('userId').equals(req.user._id),
         // TODO: add isLiked field
     }))
     res.status(200).json({

--- a/apps/server/src/models/comments.ts
+++ b/apps/server/src/models/comments.ts
@@ -12,9 +12,6 @@ export class Comments extends defaultClasses.TimeStamps {
     @prop({ ref: User, required: true })
     public userId: mongoose.Types.ObjectId
 
-    @prop({ required: true })
-    public nickname: string
-
     @prop({ ref: Events, required: true })
     public eventId: mongoose.Types.ObjectId
 
@@ -31,7 +28,6 @@ export class Comments extends defaultClasses.TimeStamps {
         return {
             _id: this._id,
             userId: this.userId,
-            nickname: this.nickname,
             eventId: this.eventId,
             comment: this.comment,
             createdAt: this.createdAt,
@@ -47,7 +43,17 @@ export class Comments extends defaultClasses.TimeStamps {
             limit: number
         },
     ): Promise<mongoose.PaginateResult<mongoose.PaginateDocument<typeof Comments, object, object, mongoose.PaginateOptions>>> {
-        return await this.paginate({ eventId: eventId }, options)
+        return await this.paginate(
+            { eventId: eventId },
+            {
+                ...options,
+                populate: {
+                    path: 'userId',
+                    select: 'nickname isDeleted',
+                    model: 'User',
+                },
+            },
+        )
     }
 }
 

--- a/apps/server/src/models/review.ts
+++ b/apps/server/src/models/review.ts
@@ -48,7 +48,7 @@ export class Reviews extends defaultClasses.TimeStamps {
                 ...options,
                 populate: {
                     path: 'userId',
-                    select: 'nickname',
+                    select: 'nickname isDeleted',
                     model: 'User',
                 },
             },

--- a/apps/server/src/models/user.ts
+++ b/apps/server/src/models/user.ts
@@ -36,6 +36,7 @@ export class User extends defaultClasses.TimeStamps implements IUser {
             _id: this._id,
             nickname: this.nickname,
             provider: this.provider,
+            isDeleted: this.isDeleted,
         }
     }
 

--- a/apps/web/src/components/comment/comment.tsx
+++ b/apps/web/src/components/comment/comment.tsx
@@ -41,7 +41,7 @@ export function EventComment({ comment }: Props) {
             {deleteMutation.isPending && <LoadingOverlay />}
             <div className="flex justify-between items-center">
                 <div>
-                    <div className="text-sm text-gray-500">{comment.nickname}</div>
+                    <div className="text-sm text-gray-500">{comment.userId?.isDeleted ? `탈퇴한 회원` : comment.userId?.nickname}</div>
                     {isEdit ? (
                         <CommentUpdateField comment={comment} onSuccess={() => setIsEdit(false)} />
                     ) : (

--- a/apps/web/src/components/review/review.tsx
+++ b/apps/web/src/components/review/review.tsx
@@ -32,7 +32,7 @@ export default function Review({ review }: Props) {
     return (
         <div className="flex flex-col w-full gap-2.5 pt-2.5 overflow-hidden">
             <div className="flex flex-col gap-[0.3125rem] px-2.5 pt-[0.3125rem]">
-                <span className="text-sm">{review.userId.nickname}</span>
+                <span className="text-sm">{review.userId.isDeleted ? `탈퇴한 회원` : review.userId.nickname}</span>
                 <div className="flex flex-row justify-between">
                     <div className="flex flex-row gap-1.5">
                         <div className="flex flex-row gap-[0.1875rem]">

--- a/packages/types/api/events.ts
+++ b/packages/types/api/events.ts
@@ -99,10 +99,14 @@ export interface IComment {
     _id: string
     eventId: string
     comment: string
-    nickname: string
     isAuthor: boolean
     createdAt: Date
     updatedAt: Date
+    userId: {
+        _id: string
+        nickname: string
+        isDeleted: boolean
+    }
 }
 
 export interface IGetEventCommentsResponse {

--- a/packages/types/api/reviews.ts
+++ b/packages/types/api/reviews.ts
@@ -3,6 +3,7 @@ export interface IReview {
     userId: {
         _id: string
         nickname: string
+        isDeleted: boolean
     }
     rating: number
     body: string


### PR DESCRIPTION
탈퇴한 회원의 닉네임 표기 변경을 추가하였습니다
- isDeleted가 true인 사용자인 경우 리뷰와 댓글에서 닉네임을 탈퇴한 회원(임시로 지정하여 변경할 수 있습니다)으로 표기
- 댓글에서 닉네임을 따로 저장하지 않고 user 모델에서 불러오는 방식으로 변경
- 각 타입에 isDeleted 추가
- User 모델의 toJSON에 isDeleted 추가(review에서 user 모델 필드 불러올 경우 isDeleted가 포함되기 위함)

<img width="279" height="570" alt="스크린샷 2025-08-18 오전 1 38 50" src="https://github.com/user-attachments/assets/6779ecfa-fb5f-4658-8316-d0bf5a230031" />

<img width="272" height="585" alt="스크린샷 2025-08-18 오전 1 39 00" src="https://github.com/user-attachments/assets/ad4e294e-5f8f-4f6d-97da-a116150229d9" />
