### PR TITLE
feat: add error handling for push notification setup

### DIFF
--- a/apps/app/src/pages/Webview.tsx
+++ b/apps/app/src/pages/Webview.tsx
@@ -57,13 +57,18 @@ export function WebviewScreen() {
 
     useEffect(() => {
         const saveFCMToken = async () => {
-            const credential = await getToken()
-            const info = await PushNotificationService.getDeviceInfo()
-            const fcmRequest: IRequestNotificationToken = {
-                body: info,
-                accessToken: credential.accessToken,
+            try {
+                const credential = await getToken()
+                const info = await PushNotificationService.getDeviceInfo()
+                const fcmRequest: IRequestNotificationToken = {
+                    body: info,
+                    accessToken: credential.accessToken,
+                }
+                await submitFCMToken(fcmRequest)
+            } catch (error) {
+                // 권한 실패 또는 FCM 토큰 생성 실패 시 에러 로깅 후 무시
+                console.error('Failed to save FCM token:', error)
             }
-            await submitFCMToken(fcmRequest)
         }
         saveFCMToken()
     }, [])


### PR DESCRIPTION
- 푸시 메시지 설정을 초기화할 때 에러 핸들링을 추가하여 글로벌 에러 핸들링으로 넘어가지 않도록 조정합니다.
- 권한 실패의 경우 사용자가 알람 권한을 부여하지 않은 경우가 있을 수 있음으로, 따로 에러 처리를 하지 않고 로그만 생성하는 방식으로 에러를 핸들링하도록 하였습니다.