### PR TITLE
fix: remove res.json() to resolve FCM token request error

### DIFF
--- a/apps/app/src/api/notification.ts
+++ b/apps/app/src/api/notification.ts
@@ -11,6 +11,4 @@ export async function submitFCMToken(request: IRequestNotificationToken): Promis
     if (!res.ok) {
         throw await res.json()
     }
-
-    return res.json()
 }


### PR DESCRIPTION
FCM 토큰 전송 API가 서버에서 204 No Content 상태 코드를 반환하여 클라이언트에서 JSON 파싱 오류가 발생했습니다. 불필요한 res.json() 구문을 제거하여 오류를 해결했습니다.