### PR TITLE
feat: add address input feature for event and schedule registration

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -31,6 +31,7 @@ router.post('/', verifyToken, async (req: Request, res: Response) => {
     await EventsModel.create({
         name: req.body.name,
         authorId: req.user._id,
+        address: req.body.address,
         location: req.body.location,
         startDate: req.body.startDate,
         endDate: req.body.endDate,
@@ -49,6 +50,7 @@ router.put('/:id', verifyToken, verifyEventAuthor, async (req: Request, res: Res
         { _id: req.params.id },
         {
             name: req.body.name,
+            address: req.body.address,
             location: req.body.location,
             startDate: req.body.date,
             endDate: req.body.endDate,

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -20,7 +20,7 @@ const geistMono = localFont({
     variable: '--font-geist-mono',
     weight: '100 900',
 })
-const KAKAO_SDK_URL = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_API_KEY}&autoload=false`
+const KAKAO_SDK_URL = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_API_KEY}&autoload=false&libraries=services`
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
     return (

--- a/apps/web/src/components/events/eventForm.tsx
+++ b/apps/web/src/components/events/eventForm.tsx
@@ -56,6 +56,10 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, handleCategor
         setFormData(prevState => ({ ...prevState, isAllDay: !prevState.isAllDay }))
     }
 
+    const onAddressChange = (address: string): void => {
+        setFormData(prevState => ({ ...prevState, address }))
+    }
+
     const queryClient = useQueryClient()
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault()
@@ -128,10 +132,12 @@ const EventForm: React.FC<EventFormProps> = ({ selectedCategories, handleCategor
                         onEndDateChange={onEndDateTimeChange}
                     />
                 </div>
-                <div>
-                    <label className="font-medium">행사 장소</label>
-                    <EventVenueSelector initialPosition={position} onPositionChange={setPosition} />
-                </div>
+                <EventVenueSelector
+                    initialPosition={position}
+                    initialAddress={formData.address}
+                    onPositionChange={setPosition}
+                    onAddressChange={onAddressChange}
+                />
                 <InputField label="이용 요금" placeholder="₩ 이용 요금을 입력해주세요" value={formData.cost} name="cost" onChange={handleChange} />
                 <InputField
                     label="이용 대상"

--- a/apps/web/src/components/events/eventVenueSelector.tsx
+++ b/apps/web/src/components/events/eventVenueSelector.tsx
@@ -1,27 +1,147 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Map, MapMarker } from 'react-kakao-maps-sdk'
 
 interface EventVenueSelectorProps {
     initialPosition: { lat: number; lng: number }
+    initialAddress: string
     onPositionChange: (position: { lat: number; lng: number }) => void
+    onAddressChange: (address: string) => void
 }
 
-const EventVenueSelector: React.FC<EventVenueSelectorProps> = ({ initialPosition, onPositionChange }) => {
+interface PlaceResult {
+    place_name: string
+    address_name: string
+    x: string
+    y: string
+}
+
+const EventVenueSelector: React.FC<EventVenueSelectorProps> = ({ initialPosition, initialAddress, onPositionChange, onAddressChange }) => {
     const [position, setPosition] = useState(initialPosition)
+    const [address, setAddress] = useState(initialAddress ?? '')
+    const [places, setPlaces] = useState<PlaceResult[]>([])
+    const [isSelecting, setIsSelecting] = useState<boolean>(true)
+
+    useEffect(() => {
+        if (isSelecting) {
+            return setIsSelecting(false)
+        }
+
+        if (address.trim() === '') return setPlaces([])
+
+        const debounceTimer = setTimeout(() => {
+            const ps = new kakao.maps.services.Places()
+            ps.keywordSearch(address, (data, status) => {
+                if (status === kakao.maps.services.Status.OK) {
+                    setPlaces(data as PlaceResult[])
+                } else if (status === kakao.maps.services.Status.ZERO_RESULT) {
+                    setPlaces([
+                        {
+                            place_name: '장소 검색 결과가 존재하지 않습니다.',
+                            address_name: '',
+                            x: '0',
+                            y: '0',
+                        },
+                    ])
+                } else if (status === kakao.maps.services.Status.ERROR) {
+                    setPlaces([
+                        {
+                            place_name: '장소 검색 중 오류가 발생했습니다.',
+                            address_name: '',
+                            x: '0',
+                            y: '0',
+                        },
+                    ])
+                }
+            })
+        }, 500)
+        return () => {
+            clearTimeout(debounceTimer)
+        }
+    }, [address, isSelecting])
 
     const handleMapClick = (_: kakao.maps.Map, mouseEvent: kakao.maps.event.MouseEvent) => {
+        setIsSelecting(true)
+
         const newPosition = {
             lat: mouseEvent.latLng.getLat(),
             lng: mouseEvent.latLng.getLng(),
         }
         setPosition(newPosition)
         onPositionChange(newPosition)
+
+        const geocoder = new kakao.maps.services.Geocoder()
+        geocoder.coord2Address(newPosition.lng, newPosition.lat, (data, status) => {
+            if (status === kakao.maps.services.Status.OK) {
+                const target = data[0]
+                const addressText = target.address.address_name
+                setAddress(addressText)
+                onAddressChange(addressText)
+                setPlaces([])
+            } else {
+                setAddress('')
+                onAddressChange('')
+                setPlaces([
+                    {
+                        place_name: '지정된 좌표에 주소 정보를 찾을 수 없습니다.',
+                        address_name: '',
+                        x: '0',
+                        y: '0',
+                    },
+                ])
+            }
+        })
+    }
+
+    const handleSelectPlace = (place: PlaceResult) => {
+        if (place.address_name === '' && place.x === '0' && place.y === '0') return
+
+        setIsSelecting(true)
+
+        const newPosition = {
+            lat: parseFloat(place.y),
+            lng: parseFloat(place.x),
+        }
+        setPosition(newPosition)
+        onPositionChange(newPosition)
+        onAddressChange(place.place_name)
+        setAddress(`${place.place_name}(${place.address_name})`)
+        setPlaces([])
     }
 
     return (
-        <Map center={position} style={{ width: '100%', height: '200px' }} level={3} onClick={handleMapClick}>
-            <MapMarker position={position} />
-        </Map>
+        <div className="flex flex-col w-full pt-2 gap-4">
+            <label className="block text-base font-medium mb-2">행사 장소</label>
+            <div className="relative">
+                <div className="h-10 w-full rounded-lg px-4 py-2" />
+                <div className="absolute border rounded-lg w-full top-0 z-10">
+                    <input
+                        className="w-full rounded-lg px-4 py-2 focus:outline-none"
+                        type="text"
+                        name="address"
+                        value={address}
+                        onChange={({ target }) => setAddress(target.value)}
+                        placeholder="장소를 입력해주세요"
+                    />
+                    {places.length > 0 && (
+                        <ul className="w-full bg-white rounded-lg shadow-lg max-h-48 overflow-y-auto mt-1">
+                            {places.map((place, index) => (
+                                <li
+                                    key={index}
+                                    className="px-4 py-2 hover:bg-gray-100 cursor-pointer border-b"
+                                    onClick={() => handleSelectPlace(place)}
+                                >
+                                    <div className="font-semibold">{place.place_name}</div>
+                                    <div className="text-sm text-gray-500">{place.address_name}</div>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+            </div>
+            <Map center={position} style={{ width: '100%', height: '200px' }} level={4} onClick={handleMapClick}>
+                <MapMarker position={position} />
+            </Map>
+        </div>
     )
 }
 

--- a/apps/web/src/components/events/inputField.tsx
+++ b/apps/web/src/components/events/inputField.tsx
@@ -7,10 +7,11 @@ interface InputFieldProps {
     rows?: number
     name: string
     value?: string
+    className?: string
     onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void
 }
 
-const InputField: React.FC<InputFieldProps> = ({ label, placeholder, type = 'text', rows, name, value, onChange }) => {
+const InputField: React.FC<InputFieldProps> = ({ className, label, placeholder, type = 'text', rows, name, value, onChange }) => {
     return (
         <div>
             <label className="block text-base font-medium mb-2">{label}</label>
@@ -18,7 +19,7 @@ const InputField: React.FC<InputFieldProps> = ({ label, placeholder, type = 'tex
                 <textarea
                     name={name}
                     placeholder={placeholder}
-                    className="w-full border rounded-lg px-4 py-2"
+                    className={`${className ?? 'w-full border rounded-lg px-4 py-2'}`}
                     rows={rows}
                     value={value}
                     onChange={onChange}

--- a/apps/web/src/components/schedules/scheduleForm.tsx
+++ b/apps/web/src/components/schedules/scheduleForm.tsx
@@ -36,6 +36,10 @@ export default function ScheduleForm() {
         setFormData(prevState => ({ ...prevState, location: { type: 'Point', coordinates: [position.lng, position.lat] } }))
     }
 
+    const onAddressChange = (address: string) => {
+        setFormData(prevState => ({ ...prevState, address }))
+    }
+
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target
         setFormData(prevState => ({ ...prevState, [name]: value }))
@@ -87,13 +91,12 @@ export default function ScheduleForm() {
                     />
                 </div>
                 {!formData.eventId && (
-                    <div className="flex flex-col mb-6 w-full">
-                        <label className="font-medium">일정 장소</label>
-                        <EventVenueSelector
-                            initialPosition={{ lat: formData.location.coordinates[1], lng: formData.location.coordinates[0] }}
-                            onPositionChange={onPositionChange}
-                        />
-                    </div>
+                    <EventVenueSelector
+                        initialPosition={{ lat: formData.location.coordinates[1], lng: formData.location.coordinates[0] }}
+                        initialAddress={formData.address}
+                        onPositionChange={onPositionChange}
+                        onAddressChange={onAddressChange}
+                    />
                 )}
                 <div className="w-full mt-10 flex flex-row justify-between gap-5 flex-center item-center">
                     <button type="submit" className="w-full bg-[#FF9575] text-white font-semibold p-2 rounded-lg hover:bg-[#FF7A58]">

--- a/apps/web/src/components/schedules/scheduleUpdate.tsx
+++ b/apps/web/src/components/schedules/scheduleUpdate.tsx
@@ -49,6 +49,14 @@ export default function ScheduleUpdateModal({ isOpen, onClose, initSchedule, set
         setScheduleForm(prevState => ({ ...prevState, endDate: new Date(dateTime) }))
     }
 
+    const onPositionChange = (position: { lat: number; lng: number }): void => {
+        setScheduleForm(prev => ({ ...prev!, location: { type: 'Point', coordinates: [position.lng, position.lat] } }))
+    }
+
+    const onAddressChange = (address: string) => {
+        setScheduleForm(prevState => ({ ...prevState, address }))
+    }
+
     if (!isOpen || !schedule) return null
 
     return (
@@ -78,32 +86,15 @@ export default function ScheduleUpdateModal({ isOpen, onClose, initSchedule, set
                                 onEndDateChange={onEndDateTimeChange}
                             />
                             <div className="mb-4 py-2">
-                                <div className="mt-2 mb-4">
-                                    <InputField
-                                        label="장소"
-                                        placeholder="장소를 입력해주세요"
-                                        value={schedule.address}
-                                        name="address"
-                                        onChange={handleChange}
-                                    />
-                                </div>
-                                <div className="mt-2 border border-gray-200 rounded-lg h-32 overflow-hidden">
-                                    <EventVenueSelector
-                                        initialPosition={{
-                                            lat: schedule.location.coordinates[1],
-                                            lng: schedule.location.coordinates[0],
-                                        }}
-                                        onPositionChange={newPosition =>
-                                            setScheduleForm(prev => ({
-                                                ...prev!,
-                                                location: {
-                                                    type: 'Point',
-                                                    coordinates: [newPosition.lng, newPosition.lat],
-                                                },
-                                            }))
-                                        }
-                                    />
-                                </div>
+                                <EventVenueSelector
+                                    initialPosition={{
+                                        lat: schedule.location.coordinates[1],
+                                        lng: schedule.location.coordinates[0],
+                                    }}
+                                    initialAddress={schedule.address}
+                                    onPositionChange={onPositionChange}
+                                    onAddressChange={onAddressChange}
+                                />
                             </div>
 
                             <hr className="border-t border-gray-300 mb-4" />

--- a/packages/types/api/schedules.ts
+++ b/packages/types/api/schedules.ts
@@ -4,7 +4,7 @@ export interface IMakeNewScheduleRequest {
     isAllDay: boolean
     startDate: Date
     endDate: Date
-    address?: string
+    address: string
     location: {
         type: string
         coordinates: number[]


### PR DESCRIPTION
## 변경사항

- 마커 클릭 시 위도, 좌표 값을 지번 주소로 변경하여 `address`에 등록하는 로직 추가
- 장소 이름을 검색할 시 장소 이름을 검색해서 확인하여 장소를 선택할 수 있는 로직 추가
- 행사 등록시 address를 등록하지 않고 있어 이 부분을 추가합니다. (작업은 분리해야하는 경우 따로 PR을 올리도록 하겠습니다.)

## 화면 이미지

<img width="224" height="481" alt="image" src="https://github.com/user-attachments/assets/afdacb9c-42e7-4c07-af5e-1df28b159348" />

<img width="224" height="481" alt="image" src="https://github.com/user-attachments/assets/df576437-f2f1-415e-a874-9f07ed65e7b7" />

<img width="224" height="481" alt="image" src="https://github.com/user-attachments/assets/7ea3bca9-995b-4237-b169-b9fe104ebced" />

- 위 이미지는 행사 등록의 이미지지만, 일정 등록, 수정도 동일한 UI가 노출됩니다.
