### PR TITLE
feat: set up daily task to fetch and update Tour festival data

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -10,7 +10,6 @@ import Scheduler from '@/scheduler'
 
     scheduler.run()
     server.listen()
-
     async function shutdown() {
         logger.info('gracefully shutdown fienmee')
         await Promise.all([server.close, scheduler.stop])

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -10,6 +10,7 @@ import Scheduler from '@/scheduler'
 
     scheduler.run()
     server.listen()
+
     async function shutdown() {
         logger.info('gracefully shutdown fienmee')
         await Promise.all([server.close, scheduler.stop])

--- a/apps/server/src/config/index.ts
+++ b/apps/server/src/config/index.ts
@@ -13,6 +13,8 @@ export const {
     JWT_SECRET,
     SEOUL_API_KEY,
     SEOUL_API_URL,
+    TOUR_API_KEY,
+    TOUR_API_URL,
     AWS_ACCESS_KEY_ID,
     AWS_SECRET_ACCESS_KEY,
     AWS_REGION,

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -14,6 +14,13 @@ export default class DateBatchScheduler {
                 logger.error(`Seoul Data Scheduler failed.`, { error: error })
             }
         })
+        schedule.scheduleJob('0 2 * * *', async () => {
+            try {
+                logger.info('Scheduler job started for Tour Api Data update')
+            } catch (error) {
+                logger.error(`Tour Api Data Scheduler failed.`, { error: error })
+            }
+        })
 
         schedule.scheduleJob('0 3 * * *', async () => {
             try {

--- a/apps/server/src/services/tourApi/databatch.ts
+++ b/apps/server/src/services/tourApi/databatch.ts
@@ -1,0 +1,99 @@
+import { getTourDataDetail, getTourFestivalData, getTourFestivalDataInfo } from '@/services/tourApi/tour.data'
+import { ITourDataInfo, ITourFestivalData } from '@/types/tour.data'
+import { toZonedTime } from 'date-fns-tz'
+import { CategoryCode, categoryMapTourCodeToCode } from '@fienmee/types'
+import { EventsModel } from '@/models'
+import { logger } from '@/utils/logger'
+import { TourDataUpdateError } from '@/types/errors'
+import { parse, set } from 'date-fns'
+
+const BATCH_SIZE = 100
+
+function parseDate(date: string): Date {
+    return parse(date, 'yyyyMMdd', new Date())
+}
+
+function parseEndDate(date: string): Date {
+    const parsedDate = parseDate(date)
+    const finalDate = set(parsedDate, { hours: 23, minutes: 59, seconds: 59 })
+    return toZonedTime(finalDate, 'Asia/Seoul')
+}
+
+function getCopyrightText(cpyrhDivCd: string): string {
+    return cpyrhDivCd === 'Type1' || cpyrhDivCd === 'Type3' ? '해당 데이터는 한국관광공사에서 제공됨을 알려드립니다.' : ''
+}
+
+function makeDescription(eventDescription: ITourDataInfo[]) {
+    const description = []
+    eventDescription.sort((a, b) => parseInt(a.serialnum) - parseInt(b.serialnum))
+    eventDescription.forEach(item => description.push(`${item.infoname}: ${item.infotext}`))
+    return description.join('\n')
+}
+
+async function saveTourData(data: ITourFestivalData[], today: Date) {
+    const bulkOps = []
+    for (const event of data) {
+        const startDate = toZonedTime(parseDate(event.eventstartdate), 'Asia/Seoul')
+        const endDate = parseEndDate(event.eventenddate)
+        if (startDate < today && endDate < today) continue
+
+        const [eventDetail, eventDescription] = await Promise.all([getTourDataDetail(event.contentid), getTourFestivalDataInfo(event.contentid)])
+
+        const registeredAt = toZonedTime(parse(event.createdtime, 'yyyyMMddHHmmss', new Date()), 'Asia/Seoul')
+        const images = []
+        if (event.firstimage) images.push(event.firstimage)
+        else if (event.firstimage2) images.push(event.firstimage2)
+
+        bulkOps.push({
+            updateOne: {
+                filter: {
+                    name: event.title,
+                    registeredAt: registeredAt,
+                },
+                update: {
+                    name: event.title,
+                    address: `${event.addr1}${event.addr2 === '' ? '' : `(${event.addr2})`}`,
+                    location: {
+                        type: 'Point',
+                        coordinates: [parseFloat(event.mapx), parseFloat(event.mapy)],
+                    },
+                    startDate: startDate,
+                    endDate: endDate,
+                    description: `${makeDescription(eventDescription.response.body.items.item)}\n${getCopyrightText(event.cpyrhDivCd)}`,
+                    photo: images,
+                    cost: eventDetail.response.body.items.item.usetimefestival || '',
+                    category: [categoryMapTourCodeToCode[event.lclsSystm3] || CategoryCode.OTHERS],
+                    targetAudience: [eventDetail.response.body.items.item.agelimit],
+                    registeredAt: registeredAt,
+                },
+                upsert: true,
+            },
+        })
+    }
+    try {
+        if (bulkOps.length > 0) {
+            await EventsModel.bulkWrite(bulkOps)
+            logger.info(`Successfully updated ${bulkOps.length} pieces of Tour API festival information in mongo DB`)
+        } else {
+            logger.info(`No new Tour API festival information found, so no update is performed`)
+        }
+    } catch (error) {
+        throw new TourDataUpdateError(error)
+    }
+}
+
+export async function fetchAndSaveTourFestivalData(): Promise<void> {
+    let index = 1
+    let hasMoreData = true
+    let dataCount = 0
+    const today = new Date()
+    while (hasMoreData) {
+        const result = await getTourFestivalData(today, index, BATCH_SIZE)
+        const body = result.response.body
+        await saveTourData(body.items.item, today)
+        await new Promise(resolve => setTimeout(resolve, 500)) // 각 요청마다 500ms 간격 추가
+        dataCount += body.numOfRows
+        if (dataCount < body.totalCount) index++
+        else hasMoreData = false
+    }
+}

--- a/apps/server/src/services/tourApi/tour.data.ts
+++ b/apps/server/src/services/tourApi/tour.data.ts
@@ -1,0 +1,70 @@
+import { TOUR_API_KEY, TOUR_API_URL } from '@/config'
+import { TourDataServerError } from '@/types/errors'
+import { format } from 'date-fns'
+import { IResponseFestivalApi, IResponseFestivalDetailApi, IResponseFestivalInfoApi } from '@/types/tour.data'
+
+const defaultParams = {
+    MobileApp: 'Fienmee',
+    MobileOS: 'WEB',
+    ServiceKey: TOUR_API_KEY,
+    _type: 'json',
+}
+
+export async function getTourFestivalData(startDate: Date, page: number, limit: number): Promise<IResponseFestivalApi> {
+    const params = new URLSearchParams({
+        ...defaultParams,
+        eventStartDate: format(startDate, 'yyyyMMdd'),
+        pageNo: String(page),
+        numOfRows: String(limit),
+        arrange: 'R',
+    })
+    const res = await fetch(`${TOUR_API_URL}/searchFestival2?${params.toString()}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+    const data = (await res.json()) as IResponseFestivalApi
+    if (data.response.header.resultCode !== '0000') {
+        throw new TourDataServerError()
+    }
+    return data
+}
+
+export async function getTourDataDetail(contentId: string): Promise<IResponseFestivalDetailApi> {
+    const params = new URLSearchParams({
+        ...defaultParams,
+        contentId: contentId,
+        contentTypeId: '15',
+    })
+    const res = await fetch(`${TOUR_API_URL}/detailIntro2?${params.toString()}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+    const data = (await res.json()) as IResponseFestivalDetailApi
+    if (data.response.header.resultCode !== '0000') {
+        throw new TourDataServerError()
+    }
+    return data
+}
+
+export async function getTourFestivalDataInfo(contentId: string): Promise<IResponseFestivalInfoApi> {
+    const params = new URLSearchParams({
+        ...defaultParams,
+        contentId: contentId,
+        contentTypeId: '15',
+    })
+    const res = await fetch(`${TOUR_API_URL}/detailInfo2?${params.toString()}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+    })
+    const data = (await res.json()) as IResponseFestivalInfoApi
+    if (data.response.header.resultCode !== '0000') {
+        throw new TourDataServerError()
+    }
+    return data
+}

--- a/apps/server/src/types/errors/databatch.ts
+++ b/apps/server/src/types/errors/databatch.ts
@@ -15,3 +15,19 @@ export class SeoulDataUpdateError extends APIError {
         Error.captureStackTrace(this, SeoulDataServerError)
     }
 }
+
+export class TourDataServerError extends APIError {
+    constructor(cause: Error | string = null) {
+        super(500, 5002, 'tour data server error', cause)
+        Object.setPrototypeOf(this, TourDataServerError.prototype)
+        Error.captureStackTrace(this, TourDataServerError)
+    }
+}
+
+export class TourDataUpdateError extends APIError {
+    constructor(cause: Error | string = null) {
+        super(500, 5003, 'tour data update error', cause)
+        Object.setPrototypeOf(this, TourDataServerError.prototype)
+        Error.captureStackTrace(this, TourDataServerError)
+    }
+}

--- a/apps/server/src/types/tour.data.ts
+++ b/apps/server/src/types/tour.data.ts
@@ -1,0 +1,113 @@
+export interface ICommonTourData {
+    contentid: string // 콘텐츠 ID
+    contenttypeid: string // 관광타입 ID
+    title: string // 제목
+    createdtime: string // 등록일
+    modifiedtime: string // 콘텐츠 수정일
+    tel: string // 전화번호
+    firstimage: string // 원본 대표 이미지
+    firstimage2: string // 썸내일 대표 이미지
+    cpyrhDivCd: string // 저작권 유형 (1-출처표시, 3-출처표시+변경금지)
+    areacode: string // 지역 코드
+    sigungucode: string // 시군구코드
+    lDongRegnCd: string // 법정동 시도 코드
+    lDongSignguCd: string // 법정동 시군구 코드
+    lclsSystm1: string // 분류체계 대분류
+    lclsSystm2: string // 분류체계 중분류
+    lclsSystm3: string // 분류체계 소분류
+    cat1: string // 대분류 코드
+    cat2: string // 중분류 코드
+    cat3: string // 소분류 코드
+    addr1: string // 주소
+    addr2: string // 상세 주소
+    zipcode: string // 우편 번호
+    mapx: string // 경도
+    mapy: string // 위도
+    mlevel: string // Map Level 응답
+}
+
+export interface IFestivalBaseData {
+    eventstartdate: string // 행사 시작일
+    eventenddate: string // 행사 종료일
+    progresstype: string // 진행 상태 정보
+    festivaltype: string // 축제 유형명
+}
+
+export interface ITourFestivalData extends ICommonTourData, IFestivalBaseData {}
+
+export interface ITourDataDetail extends IFestivalBaseData {
+    contentid: string
+    contenttypeid: string
+    sponsor1: string // 주죄자1 정보
+    sponsor1tel: string // 주최자1 번호
+    sponsor2: string // 주최자2 정보
+    sponsor2tel: string // 주최자2 번호
+    playtime: string // 공연시간
+    eventplace: string // 행사장소
+    eventhompage: string // 행사홈페이지
+    agelimit: string // 관람가능연령
+    bookingplace: string // 예매처
+    placeinfo: string // 행사장위치안내
+    subevent: string // 부대행사
+    program: string // 행사 프로그램
+    usetimefestival: string // 이용요금
+    discountinfofestival: string // 할인정보
+    spendtimefestival: string // 관람소요시간
+    festivalgrade: string // 축제등급
+}
+
+export interface ITourDataInfo {
+    contentid: string
+    contenttypeid: string
+    serialnum: string // 반복 일련번호
+    infoname: string // 설명 제목
+    infotext: string // 설명 내용
+    fldgubun: string // 일련 번호
+}
+
+export interface IResponseTourApiHeader {
+    resultCode: string
+    resultMsg: string
+}
+
+export interface IResponseFestivalApi {
+    response: {
+        header: IResponseTourApiHeader
+        body: {
+            numOfRows: number
+            pageNo: number
+            totalCount: number
+            items: {
+                item: ITourFestivalData[]
+            }
+        }
+    }
+}
+
+export interface IResponseFestivalDetailApi {
+    response: {
+        header: IResponseTourApiHeader
+        body: {
+            numOfRows: number
+            pageNo: number
+            totalCount: number
+            items: {
+                item: ITourDataDetail
+            }
+        }
+    }
+}
+
+export interface IResponseFestivalInfoApi {
+    response: {
+        header: IResponseTourApiHeader
+        body: {
+            numOfRows: number
+            pageNo: number
+            totalCount: number
+            items: {
+                item: ITourDataInfo[]
+            }
+        }
+    }
+}

--- a/packages/types/api/category.ts
+++ b/packages/types/api/category.ts
@@ -38,6 +38,29 @@ export const categoryMapTitleToCode = {
     클래식: CategoryCode.MUSIC,
 }
 
+export const categoryMapTourCodeToCode = {
+    EV010100: CategoryCode.ARTS, // 문화관광축제
+    EV010200: CategoryCode.ARTS, // 문화예술축제
+    EV010300: CategoryCode.FOOD_DRINKS, // 지역특산물축제
+    EV010400: CategoryCode.OTHERS, // 전통역사 축제
+    EV010500: CategoryCode.NATURE_OUTDOORS, // 생태자연축제
+    EV010600: CategoryCode.OTHERS, // 기타 축제
+    EV020100: CategoryCode.ARTS, // 전통공연
+    EV020200: CategoryCode.ARTS, // 연극
+    EV020300: CategoryCode.MUSIC, // 뮤지컬
+    EV020400: CategoryCode.MUSIC, // 오페라
+    EV020500: CategoryCode.MUSIC, // 무용
+    EV020600: CategoryCode.MUSIC, // 클래식음악회
+    EV020700: CategoryCode.MUSIC, // 대중콘서트
+    EV020800: CategoryCode.MOVIE_TV, // 영화
+    EV020900: CategoryCode.OTHERS, // 기타 공연
+    EV021000: CategoryCode.ARTS, // 넌버벌
+    EV030100: CategoryCode.ARTS, // 전시회
+    EV030200: CategoryCode.OTHERS, // 박람회
+    EV030300: CategoryCode.SPORTS, // 스포츠경기
+    EV030400: CategoryCode.OTHERS, // 기타행사
+}
+
 export const fixedCategory = {
     [CategoryCode.MYEVENT]: { title: '내가 등록한 행사', code: CategoryCode.MYEVENT, type: 'special' },
     [CategoryCode.HOTEVENT]: { title: '인기 행사', code: CategoryCode.HOTEVENT, type: 'special' },


### PR DESCRIPTION
- 한국 관광공사의 TourAPI 4.0을 이용하여 행사 정보를 가져오고, 업데이트하는 함수 추가
- 새벽 1시에 TourAPI의 변경사항들이 수정되기 때문에 여유를 가지고 새벽 2시에 스케쥴러가 업데이트 진행

카테고리 내용을 확인해서 현재 있는 카테고리에 매칭했는데, 해당 부분 한번 확인해주시면 감사할 것 같습니다. 