### PR TITLE
chore: install ca-certificates on docker container

### DIFF
--- a/Dockerfile_SERVER
+++ b/Dockerfile_SERVER
@@ -24,6 +24,8 @@ RUN pnpm build:server
 
 FROM base AS runner
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
 COPY --from=build /fienmee/apps/server/package.json /fienmee/apps/server/package.json
 COPY --from=build /fienmee/apps/server/dist /fienmee/apps/server/dist
 COPY --from=build /fienmee/apps/server/newrelic.cjs /fienmee/apps/server/dist/newrelic.cjs

--- a/Dockerfile_SERVER
+++ b/Dockerfile_SERVER
@@ -24,7 +24,7 @@ RUN pnpm build:server
 
 FROM base AS runner
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /fienmee/apps/server/package.json /fienmee/apps/server/package.json
 COPY --from=build /fienmee/apps/server/dist /fienmee/apps/server/dist

--- a/Dockerfile_WEB
+++ b/Dockerfile_WEB
@@ -13,6 +13,8 @@ RUN pnpm build:web
 
 FROM node:20-slim AS web
 
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
 COPY --from=build /fienmee/apps/web/.next/standalone /fienmee
 COPY --from=build /fienmee/apps/web/.next/static /fienmee/apps/web/.next/static
 COPY --from=build /fienmee/apps/web/public /fienmee/apps/web/public

--- a/Dockerfile_WEB
+++ b/Dockerfile_WEB
@@ -13,7 +13,7 @@ RUN pnpm build:web
 
 FROM node:20-slim AS web
 
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /fienmee/apps/web/.next/standalone /fienmee
 COPY --from=build /fienmee/apps/web/.next/static /fienmee/apps/web/.next/static


### PR DESCRIPTION
현재 사용중인 node:20-slim 이미지에 ca-certificates 가 없어 설치합니다
