### PR TITLE
fix: 과거 notifee 리시버 제거

### DIFF
--- a/apps/app/android/app/src/main/AndroidManifest.xml
+++ b/apps/app/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest
+﻿<manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="beyondimagination.fienmee"
 >
@@ -33,7 +33,7 @@
             <category android:name="android.intent.category.DEFAULT" />
             <category android:name="android.intent.category.BROWSABLE" />
 
-            <!-- Redirect URI: "kakao{NATIVE_APP_KEY}://oauth“ -->
+            <!-- Redirect URI: "kakao{NATIVE_APP_KEY}://oauth??-->
             <data android:host="oauth"
                   android:scheme="kakao6754084b45fdd747c58d0b8ce588e70b" />
         </intent-filter>
@@ -48,12 +48,5 @@
       <service
         android:name="io.invertase.firebase.messaging.ReactNativeFirebaseMessagingHeadlessService"
         android:exported="false" />
-      <receiver android:name="app.notifee.receivers.NotificationReceiver" android:exported="true" />
-      <receiver android:name="app.notifee.receivers.BootReceiver" android:enabled="true" android:exported="true">
-        <intent-filter>
-          <action android:name="android.intent.action.BOOT_COMPLETED"/>
-          <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
-        </intent-filter>
-      </receiver>
     </application>
 </manifest>


### PR DESCRIPTION
현재 앱은 @notifee/react-native 9.1.8을 사용합니다
이 버전부터는 부팅/알람 관련 리시버가 라이브러리 app.notifee.core.* 로 제공됩니다.    
매니페스트에 남아 있던 app.notifee.receivers.BootReceiver/NotificationReceiver는 이미 존재하지 않는 API라 런타임에 ClassNotFoundException을 일으켜 앱이 부팅 즉시 충돌이 나는 증상을 해결합니다. 