### PR TITLE
feat: 댓글 likeCount 응답 포함 및 웹 좋아요 토글 연동

### DIFF
--- a/apps/server/src/controllers/v1/events.ts
+++ b/apps/server/src/controllers/v1/events.ts
@@ -201,6 +201,7 @@ router.get('/:id/comments', verifyToken, async (req: Request, res: Response) => 
         ...comment.toObject(),
         isAuthor: comment.get('userId')?.equals(req.user._id),
         isLiked: comment.get('likes')?.includes(req.user._id),
+        likeCount: comment.get('likes')?.length || 0,
     }))
     res.status(200).json({
         comments: modifiedDocs,

--- a/apps/web/src/api/event.ts
+++ b/apps/web/src/api/event.ts
@@ -131,3 +131,13 @@ export async function deleteEventCommentById(request: IDeleteCommentRequest): Pr
     }
     return
 }
+
+export async function toggleEventCommentLike(eventId: string, commentId: string): Promise<void> {
+    const res = await fetch(`${SERVER_URL}/v1/events/${eventId}/comments/${commentId}/likes`, {
+        method: 'POST',
+    })
+    if (!res.ok) {
+        throw await res.json()
+    }
+    return
+}

--- a/apps/web/src/components/comment/comment.tsx
+++ b/apps/web/src/components/comment/comment.tsx
@@ -3,10 +3,10 @@ import { IComment, IDeleteCommentRequest } from '@fienmee/types'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'react-toastify'
 
-import { deleteEventCommentById } from '@/api/event'
+import { deleteEventCommentById, toggleEventCommentLike } from '@/api/event'
 import CommentOption from '@/components/comment/commentOption'
 import CommentUpdateField from '@/components/comment/commentUpdateField'
-import { UnlikeIcon } from '@/components/icon'
+import { LikeIcon, UnlikeIcon } from '@/components/icon'
 import LoadingOverlay from '@/components/comment/commentLoadingOverlay'
 
 interface Props {
@@ -36,6 +36,21 @@ export function EventComment({ comment }: Props) {
         })
     }
 
+    const likeMutation = useMutation({
+        mutationFn: ({ eventId, commentId }: { eventId: string; commentId: string }) => toggleEventCommentLike(eventId, commentId),
+        onSuccess: async () => {
+            await queryClient.invalidateQueries({ queryKey: ['comments', comment.eventId] })
+        },
+        onError: () => {
+            toast.error(<span>좋아요 처리에 실패했습니다.</span>)
+        },
+    })
+
+    const handleToggleLike = () => {
+        if (likeMutation.isPending) return
+        likeMutation.mutate({ eventId: comment.eventId, commentId: comment._id })
+    }
+
     return (
         <div className="flex flex-col gap-6 py-2 relative">
             {deleteMutation.isPending && <LoadingOverlay />}
@@ -49,7 +64,16 @@ export function EventComment({ comment }: Props) {
                     )}
                 </div>
                 <div className="flex flex-row justify-center items-center gap-2">
-                    <UnlikeIcon width="1.5rem" height="1.25rem" />
+                    <button
+                        aria-label="toggle comment like"
+                        onClick={handleToggleLike}
+                        disabled={likeMutation.isPending}
+                        className="disabled:opacity-50"
+                        type="button"
+                    >
+                        {comment.isLiked ? <LikeIcon width="1.5rem" height="1.25rem" /> : <UnlikeIcon width="1.5rem" height="1.25rem" />}
+                    </button>
+                    <span className="text-sm">{comment.likeCount}</span>
                     {comment.isAuthor && (
                         <CommentOption onEdit={() => setIsEdit(true)} onDelete={handleDelete} isDeleteDisabled={deleteMutation.isPending} />
                     )}

--- a/apps/web/src/components/comment/comment.tsx
+++ b/apps/web/src/components/comment/comment.tsx
@@ -42,7 +42,7 @@ export function EventComment({ comment }: Props) {
             await queryClient.invalidateQueries({ queryKey: ['comments', comment.eventId] })
         },
         onError: () => {
-            toast.error(<span>좋아요 처리에 실패했습니다.</span>)
+            toast.error(<span>좋아요가 제대로 반영되지 않았어요. 다시 시도해주세요.</span>)
         },
     })
 


### PR DESCRIPTION
<img width="349" height="771" alt="image" src="https://github.com/user-attachments/assets/76316f51-326a-466e-abff-4baf13f6c82f" />
<img width="350" height="771" alt="image" src="https://github.com/user-attachments/assets/d39be5da-390e-46e1-99d9-b7c6b7224e61" />

DB에는 likes 배열만 저장되고 컨트롤러에서 내려주지 않으면 응답에 없어서
모델쪽에서 toJSON()에서만 likeCount = likes.length 계산               
컨트롤러는 toObject() 기반으로 응답 생성 -> ikeCount 미포함     

웹: 댓글 좋아요 토글 기능 추가  
서버: 댓글 리스트 응답에 likeCount 포함

위 내용을 구현했습니다.

제가 한건 likeCount 계산 위치가 지금 컨트롤러라 추후에 바꿔야 할 수도 있을것 같습니다.