### PR TITLE
fix: mongo timezone error due to encoding

### DIFF
--- a/apps/web/src/api/schedules.ts
+++ b/apps/web/src/api/schedules.ts
@@ -56,7 +56,7 @@ export async function updateSchedule(schedule: IScheduleItem): Promise<ISchedule
 }
 
 export async function getDailyScheduleCount(from: Date, to: Date): Promise<IGetDailyScheduleCountResponse> {
-    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    const timezone = encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone)
     const res = await fetch(`${SERVER_URL}/v1/schedules/dailyCount?from=${from.toISOString()}&to=${to.toISOString()}&timezone=${timezone}`, {
         method: 'GET',
     })

--- a/apps/web/src/api/schedules.ts
+++ b/apps/web/src/api/schedules.ts
@@ -56,8 +56,12 @@ export async function updateSchedule(schedule: IScheduleItem): Promise<ISchedule
 }
 
 export async function getDailyScheduleCount(from: Date, to: Date): Promise<IGetDailyScheduleCountResponse> {
-    const timezone = encodeURIComponent(Intl.DateTimeFormat().resolvedOptions().timeZone)
-    const res = await fetch(`${SERVER_URL}/v1/schedules/dailyCount?from=${from.toISOString()}&to=${to.toISOString()}&timezone=${timezone}`, {
+    const params = new URLSearchParams({
+        from: from.toISOString(),
+        to: to.toISOString(),
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    })
+    const res = await fetch(`${SERVER_URL}/v1/schedules/dailyCount?${params.toString()}`, {
         method: 'GET',
     })
     if (!res.ok) {


### PR DESCRIPTION
/schedule/daliyCount 호출 시 타임 존의 값이 오프셋으로 가는 경우가 있는데, 이 과정에서 인코딩이 없어 +를 공백 문자로 인식하는 문제를 수정합니다.